### PR TITLE
Remove encoders and fix more ground stations

### DIFF
--- a/Documentation/Kirk's Notes.txt
+++ b/Documentation/Kirk's Notes.txt
@@ -83,3 +83,25 @@ However, it gives a good idea of what the state of the art was for ground statio
 //  2000 - FM-1: QPSK [20, p.8]
 //  2003 - Intelsat general: 16QAM standards created? [29, p.C-1]
 //  2013 - FM-6: QPSK in legacy mode or 8PSK in overlay mode [20, p.8]
+
+RA noise figures
+Historical noise figures are typically given for the whole system at a given elevation (7.5 degrees)
+RA attempts to add noise based on body noise, antenna elevation, etc.
+So, find the noise RA adds and remove it from historical figures to get antenna noise in isolation
+L-band:
+elevation - atmo noise - body noise
+90 2 0
+60 2 0
+45 3 0
+30 4 0
+15 8 0
+7.5 16 0
+
+C-band:
+elevation - atmo noise - body noise
+90 29 0
+60 33 0
+45 40 0
+30 55 0
+15 96 0
+7.5 155 0

--- a/Documentation/citations.txt
+++ b/Documentation/citations.txt
@@ -59,3 +59,9 @@ List of sources and citations used for Skopos, in no particular order
 	https://www.intelsat.com/wp-content/uploads/2020/08/iess-316e.pdf
 [30] Modern Soviet Civil Telecommunications, 1986
 	https://www.cia.gov/readingroom/document/cia-rdp92b00181r000300270038-8
+[31] Lenkurt Demodulator May/June 1979
+	https://www.worldradiohistory.com/Archive-Company-Publications/Lenkurt-Demodulator/Lenkurt-Demodulator-1979-05-06-Part-II.pdf
+[32] Satellite Communications, 2018
+	https://itso.int/wp-content/uploads/2018/04/Presentation-by-Intelsat.pdf
+[33] Syncom Engineering report Volume II, 1967
+	https://ntrs.nasa.gov/api/citations/19670015715/downloads/19670015715.pdf

--- a/GameData/Skopos/telecom.cfg
+++ b/GameData/Skopos/telecom.cfg
@@ -21,7 +21,7 @@
     // the uplink in the 6 GHz range.
 
     //Standard ITU C-band fixed satellite service allocations. 500 MHz uplink, 500 MHz downlink. [32, p.4]
-	//make it 1024 so rate halvings divide evenly
+    //make it 1024 so rate halvings divide evenly
     ChannelWidth = 1.024e9
   }
 
@@ -33,7 +33,7 @@
     // ITU allocates US downlink between 11.70-12.20 GHz, and uplink between 14.0-14.5 GHz
 
     //Standard ITU Ku-band fixed satellite service allocations. 500 MHz uplink, 500 MHz downlink. [32, p.4]
-	//make it 1024 so rate halvings divide evenly
+    //make it 1024 so rate halvings divide evenly
     ChannelWidth = 1.024e9
   }
 }
@@ -152,7 +152,7 @@ skopos_telecom {
       TxPower = 59.5   //Using Mojave transmitter [4, p.7-8]. Correct for EIRP: 111 dbm-51.5 dbi = 59.5 dbm
       AMWTemp = 30    //37.7K @ 15 degrees, ~30K at zenith [33, p.132]
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
     }
     //85 ft antenna operating in C-band (ahistorical, but filling in for various other Califonia stations)
@@ -164,7 +164,7 @@ skopos_telecom {
       TxPower = 65  // same as early bird terminals [4, p.10-43]
       AMWTemp = 50  // same as early bird terminals [4, p.10-43]
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added ~1985 for Intelsat V? [5, p.IV-7]
       UPGRADE
@@ -198,7 +198,7 @@ skopos_telecom {
       TxPower = 63  // 2 kW.
       AMWTemp = 75
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK modem added 1966 for ATS-1/3 testing [4, p.13-10]
       UPGRADE
@@ -222,7 +222,7 @@ skopos_telecom {
       TxPower = 60  // 1 kW. Actually transmitted at 31.65 GHz?
       AMWTemp = 1000
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
     }
   }
@@ -244,7 +244,7 @@ skopos_telecom {
       TxPower = 70  // 10 kW.
       AMWTemp = 50
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added ~1985 for Intelsat V? [5, p.IV-7]
       UPGRADE
@@ -278,7 +278,7 @@ skopos_telecom {
       TxPower = 67.8  //6 kW
       AMWTemp = 50
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added ~1985 for Intelsat V? [5, p.IV-7]
       UPGRADE
@@ -312,7 +312,7 @@ skopos_telecom {
       TxPower = 67.8  //6 kW
       AMWTemp = 50
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added ~1985 for Intelsat V? [5, p.IV-7]
       UPGRADE
@@ -347,7 +347,7 @@ skopos_telecom {
       TxPower = 65
       AMWTemp = 120
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - 70s Comsat
+      EncoderOverride = None - 70s Comsat
       TARGET {}
     }
     //Ground station performance data [12, p.252]
@@ -359,7 +359,7 @@ skopos_telecom {
       TxPower = 65
       AMWTemp = 288
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - 70s Comsat
+      EncoderOverride = None - 70s Comsat
       TARGET {}
     }
   }
@@ -381,7 +381,7 @@ skopos_telecom {
       TxPower = 65
       AMWTemp = 288
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - 70s Comsat
+      EncoderOverride = None - 70s Comsat
       TARGET {}
     }
   }
@@ -404,7 +404,7 @@ skopos_telecom {
       TxPower = 65  //3 kW
       AMWTemp = 56
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - 70s Comsat
+      EncoderOverride = None - 70s Comsat
       TARGET {}
     }
     //Using 5-meter SBS Ku-band antenna at WD 44 Franklin Lakes as basis for commercial Ku-band stations [6, p.88]
@@ -416,7 +416,7 @@ skopos_telecom {
       TxPower = 65
       AMWTemp = 225
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - 70s Comsat
+      EncoderOverride = None - 70s Comsat
       TARGET {}
     }
   }
@@ -438,7 +438,7 @@ skopos_telecom {
       TxPower = 65  //3 kW
       AMWTemp = 78
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - 70s Comsat
+      EncoderOverride = None - 70s Comsat
       TARGET {}
     }
     //Using 5-meter SBS Ku-band antenna at WD 44 Franklin Lakes as basis for commercial Ku-band stations [6, p.88]
@@ -450,7 +450,7 @@ skopos_telecom {
       TxPower = 65
       AMWTemp = 225
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - 70s Comsat
+      EncoderOverride = None - 70s Comsat
       TARGET {}
     }
   }
@@ -472,7 +472,7 @@ skopos_telecom {
       TxPower = 61  //1.5 kW
       AMWTemp = 85
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - 70s Comsat
+      EncoderOverride = None - 70s Comsat
       TARGET {}
     }
     //Using 5-meter SBS Ku-band antenna at WD 44 Franklin Lakes as basis for commercial Ku-band stations [6, p.88]
@@ -484,7 +484,7 @@ skopos_telecom {
       TxPower = 65
       AMWTemp = 225
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - 70s Comsat
+      EncoderOverride = None - 70s Comsat
       TARGET {}
     }
   }
@@ -506,7 +506,7 @@ skopos_telecom {
       TxPower = 65  //3 kW
       AMWTemp = 112
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - 70s Comsat
+      EncoderOverride = None - 70s Comsat
       TARGET {}
     }
     //Using 5-meter SBS Ku-band antenna at WD 44 Franklin Lakes as basis for commercial Ku-band stations [6, p.88]
@@ -518,7 +518,7 @@ skopos_telecom {
       TxPower = 65
       AMWTemp = 225
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - 70s Comsat
+      EncoderOverride = None - 70s Comsat
       TARGET {}
     }
   }
@@ -540,7 +540,7 @@ skopos_telecom {
       TxPower = 61  //1.5 kW
       AMWTemp = 85
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - 70s Comsat
+      EncoderOverride = None - 70s Comsat
       TARGET {}
     }
     //Using 5-meter SBS Ku-band antenna at WD 44 Franklin Lakes as basis for commercial Ku-band stations [6, p.88]
@@ -552,7 +552,7 @@ skopos_telecom {
       TxPower = 65
       AMWTemp = 225
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - 70s Comsat
+      EncoderOverride = None - 70s Comsat
       TARGET {}
     }
   }
@@ -574,7 +574,7 @@ skopos_telecom {
       TxPower = 61  //1.5 kW
       AMWTemp = 85
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - 70s Comsat
+      EncoderOverride = None - 70s Comsat
       TARGET {}
     }
     //Using 5-meter SBS Ku-band antenna at WD 44 Franklin Lakes as basis for commercial Ku-band stations [6, p.88]
@@ -586,7 +586,7 @@ skopos_telecom {
       TxPower = 65
       AMWTemp = 225
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - 70s Comsat
+      EncoderOverride = None - 70s Comsat
       TARGET {}
     }
   }
@@ -608,7 +608,7 @@ skopos_telecom {
       TxPower = 64.8  //3 kW
       AMWTemp = 22
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - 70s Comsat
+      EncoderOverride = None - 70s Comsat
       TARGET {}
     }
     //Using 5-meter SBS Ku-band antenna at WD 44 Franklin Lakes as basis for commercial Ku-band stations [6, p.88]
@@ -620,7 +620,7 @@ skopos_telecom {
       TxPower = 65
       AMWTemp = 225
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - 70s Comsat
+      EncoderOverride = None - 70s Comsat
       TARGET {}
     }
   }
@@ -642,7 +642,7 @@ skopos_telecom {
       TxPower = 65  //3 kW
       AMWTemp = 630
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
     }
     //Using 5-meter SBS Ku-band antenna at WD 44 Franklin Lakes as basis for commercial Ku-band stations [6, p.88]
@@ -654,7 +654,7 @@ skopos_telecom {
       TxPower = 65
       AMWTemp = 225
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - 70s Comsat
+      EncoderOverride = None - 70s Comsat
       TARGET {}
     }
   }
@@ -676,7 +676,7 @@ skopos_telecom {
       TxPower = 65  //3 kW
       AMWTemp = 78
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
     }
     //Using 5-meter SBS Ku-band antenna at WD 44 Franklin Lakes as basis for commercial Ku-band stations [6, p.88]
@@ -688,7 +688,7 @@ skopos_telecom {
       TxPower = 65
       AMWTemp = 225
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - 70s Comsat
+      EncoderOverride = None - 70s Comsat
       TARGET {}
     }
   }
@@ -711,7 +711,7 @@ skopos_telecom {
       TxPower = 65      //3 kW
       AMWTemp = 150
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
     }
     //I don't know if the CTS Ku-band terminal was actually at Allan Park, but it should be close enough [4, p.19-16]
@@ -723,7 +723,7 @@ skopos_telecom {
       TxPower = 53      //200 W
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - 70s Comsat
+      EncoderOverride = None - 70s Comsat
       TARGET {}
     }
   }
@@ -745,7 +745,7 @@ skopos_telecom {
       TxPower = 65      //3 kW
       AMWTemp = 150
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - 70s Comsat
+      EncoderOverride = None - 70s Comsat
       TARGET {}
     }
   }
@@ -767,7 +767,7 @@ skopos_telecom {
       TxPower = 65      //3 kW
       AMWTemp = 150
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - 70s Comsat
+      EncoderOverride = None - 70s Comsat
       TARGET {}
     }
   }
@@ -789,7 +789,7 @@ skopos_telecom {
       TxPower = 65      //3 kW
       AMWTemp = 150
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - 70s Comsat
+      EncoderOverride = None - 70s Comsat
       TARGET {}
     }
   }
@@ -811,7 +811,7 @@ skopos_telecom {
       TxPower = 65      //3 kW
       AMWTemp = 150
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - 70s Comsat
+      EncoderOverride = None - 70s Comsat
       TARGET {}
     }
   }
@@ -834,7 +834,7 @@ skopos_telecom {
       TxPower = 43      //20 W
       AMWTemp = 670
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - 70s Comsat
+      EncoderOverride = None - 70s Comsat
       TARGET {}
     }
   }
@@ -859,7 +859,7 @@ skopos_telecom {
       TxPower = 120.828  // 1.21 GW!
       AMWTemp = 205
       ModulationBits = 2  //ASC recieve-only terminals could operate in QPSK
-	  EncoderOverride = None - 70s Comsat
+      EncoderOverride = None - 70s Comsat
       TARGET {}
     }
   }
@@ -883,7 +883,7 @@ skopos_telecom {
       TxPower = 70  //typical of second generation earth stations [4, p.10-44]
       AMWTemp = 58  //typical of second generation earth stations [4, p.10-44]
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added ~1985 for Intelsat V? [5, p.IV-7]
       UPGRADE
@@ -916,7 +916,7 @@ skopos_telecom {
       TxPower = 63
       AMWTemp = 220
       ModulationBits = 1  //FM, FSK or PSK only?.
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
       UPGRADE
       {
@@ -960,7 +960,7 @@ skopos_telecom {
       TxPower = 70  //10 kW
       AMWTemp = 58
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added ~1985 for Intelsat V? [5, p.IV-7]
       UPGRADE
@@ -996,7 +996,7 @@ skopos_telecom {
       TxPower = 63      // 2 kW.
       AMWTemp = 214     //230K-16K. Based on Syncom AN/FSC-9 terminals [4, p.8-10]. -16K for RA atmo noise
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
     }
     Antenna {
@@ -1008,7 +1008,7 @@ skopos_telecom {
       TxPower = 63  // 2 kW.
       AMWTemp = 32
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
       //Modified 1964 in preparation for Early Bird [4, p.10-43]
       UPGRADE
@@ -1055,7 +1055,7 @@ skopos_telecom {
       TxPower = 63      // 2 kW?
       AMWTemp = 214     //230K-16K. Based on Syncom AN/FSC-9 terminals [4, p.8-10]. -16K for RA atmo noise
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
     }
     //original telstar performance [4, p.6-9]
@@ -1067,7 +1067,7 @@ skopos_telecom {
       TxPower = 67  // 5 kW.
       AMWTemp = 55
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
       //Goonhilly modified in 1964 to correct poor performance in preparation for Early Bird [4, p.10-43]
       UPGRADE
@@ -1108,7 +1108,7 @@ skopos_telecom {
       TxPower = 63
       AMWTemp = 220
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
       //Raisting modified in 1964 for Relay 2 [4, p.7-8]
       //Raisting modified in 1965 in preparation for Early Bird [4, p.10-43]
@@ -1150,7 +1150,7 @@ skopos_telecom {
       TxPower = 63    //2 kW
       AMWTemp = 220
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
       UPGRADE
       {
@@ -1190,7 +1190,7 @@ skopos_telecom {
     alt = 50
     role = trx
     //L-band for Syncom [33, p.125]
-	//transmitting from 10 m antenna, recieving from 30 m antenna
+    //transmitting from 10 m antenna, recieving from 30 m antenna
     Antenna {
       TechLevel = 3
       RFBand = L (Wideband)
@@ -1199,7 +1199,7 @@ skopos_telecom {
       TxPower = 73.5  // actually transmitting in X-band. Correct for EIRP: 125 dbm - 51.5 dbi = 73.5 dbm
       AMWTemp = 60    // no elevation given
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
     }
     //10 m antenna operating in C-band (ahistorical, but filling in for various other Japanese stations)
@@ -1211,7 +1211,7 @@ skopos_telecom {
       TxPower = 73.7  // actually transmitting in X-band. Correct for EIRP: 125 dbm - 51.3 dbi = 73.5 dbm
       AMWTemp = 60    // same as L-band?
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
       //98.5ft antenna installed 1967 for ATS-1/3 [4, p.13-5]
       UPGRADE
@@ -1251,7 +1251,7 @@ skopos_telecom {
       TxPower = 70  //typical of second generation earth stations [4, p.10-44]
       AMWTemp = 58  //typical of second generation earth stations [4, p.10-44]
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added ~1985 for Intelsat V? [5, p.IV-7]
       UPGRADE
@@ -1285,7 +1285,7 @@ skopos_telecom {
       TxPower = 70  //typical of second generation earth stations [4, p.10-44]
       AMWTemp = 58  //typical of second generation earth stations [4, p.10-44]
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added ~1985 for Intelsat V? [5, p.IV-7]
       UPGRADE
@@ -1318,7 +1318,7 @@ skopos_telecom {
       TxPower = 70  //typical of second generation earth stations [4, p.10-44]
       AMWTemp = 58  //typical of second generation earth stations [4, p.10-44]
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
       //Upgraded for Intelsat III in 1970 [4, p.10-17]
       //Upgraded to what not specified, but several 97 ft antennas are present there today
@@ -1360,7 +1360,7 @@ skopos_telecom {
       TxPower = 70  //typical of second generation earth stations [4, p.10-44]
       AMWTemp = 58  //typical of second generation earth stations [4, p.10-44]
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added ~1985 for Intelsat V? [5, p.IV-7]
       UPGRADE
@@ -1394,7 +1394,7 @@ skopos_telecom {
       TxPower = 70  //typical of second generation earth stations
       AMWTemp = 58  //typical of second generation earth stations
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added ~1985 for Intelsat V? [5, p.IV-7]
       UPGRADE
@@ -1433,7 +1433,7 @@ skopos_telecom {
       TxPower = 63  // 2 kW.
       AMWTemp = 33
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
       //97ft antenna installed 1969 [4, p.10-16]
       UPGRADE
@@ -1473,7 +1473,7 @@ skopos_telecom {
       TxPower = 63  // 2 kW.
       AMWTemp = 75
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
       //Moree brought online 1968 with 92ft antenna [4, p.10-14]
       //Since it's close(ish) to Cooby Creek, just add to Cooby Creek
@@ -1668,7 +1668,7 @@ skopos_telecom {
       TxPower = 70  //typical of second generation earth stations
       AMWTemp = 58  //typical of second generation earth stations
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added ~1985 for Intelsat V? [5, p.IV-7]
       UPGRADE
@@ -1704,7 +1704,7 @@ skopos_telecom {
       TxPower = 67  // 5 kW same as C-band?
       AMWTemp = 230
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
     }
     //Ground station performance data [4, p.11-16]
@@ -1716,7 +1716,7 @@ skopos_telecom {
       TxPower = 67  // 5 kW Gradient-K transmitter [7] [8]
       AMWTemp = 230
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
       //Moscow has a standard Intelsat terminal installed 1974 [4, p.10-20]
       UPGRADE
@@ -1749,7 +1749,7 @@ skopos_telecom {
       TxPower = 62  //1.5 kW
       AMWTemp = 537
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
     }
   }
@@ -1770,7 +1770,7 @@ skopos_telecom {
       TxPower = 67  // 5 kW same as C-band?
       AMWTemp = 230
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
     }
     //Ground station performance data [4, p.11-16]
@@ -1782,7 +1782,7 @@ skopos_telecom {
       TxPower = 67  // 5 kW Gradient-K transmitter [7] [8]
       AMWTemp = 230
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added ~1983 for TDMA-40 [5, p.IV-7]
       UPGRADE
@@ -1806,7 +1806,7 @@ skopos_telecom {
       TxPower = 62  //1.5 kW
       AMWTemp = 537
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
     }
   }
@@ -1827,7 +1827,7 @@ skopos_telecom {
       TxPower = 65  // Same as C-Band?
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
     }
     //Ground station performance data [4, p.11-16]
@@ -1840,7 +1840,7 @@ skopos_telecom {
       TxPower = 65
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added ~1983 for TDMA-40 [5, p.IV-7]
       UPGRADE
@@ -1875,7 +1875,7 @@ skopos_telecom {
       TxPower = 120.828  // 1.21 GW!
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
     }
     //Ground station performance data [4, p.11-16]
@@ -1888,7 +1888,7 @@ skopos_telecom {
       TxPower = 120.828  // 1.21 GW!
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added ~1983 for TDMA-40 [5, p.IV-7]
       UPGRADE
@@ -1923,7 +1923,7 @@ skopos_telecom {
       TxPower = 120.828  // 1.21 GW!
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
     }
     //Ground station performance data [4, p.11-16]
@@ -1936,7 +1936,7 @@ skopos_telecom {
       TxPower = 120.828  // 1.21 GW!
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added ~1983 for TDMA-40 [5, p.IV-7]
       UPGRADE
@@ -1970,7 +1970,7 @@ skopos_telecom {
       TxPower = 65  // Same as C-Band?
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
     }
     //Ground station performance data [4, p.11-16]
@@ -1983,7 +1983,7 @@ skopos_telecom {
       TxPower = 65
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added ~1983 for TDMA-40 [5, p.IV-7]
       UPGRADE
@@ -2018,7 +2018,7 @@ skopos_telecom {
       TxPower = 120.828  // 1.21 GW!
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
     }
     //Ground station performance data [4, p.11-16]
@@ -2031,7 +2031,7 @@ skopos_telecom {
       TxPower = 120.828  // 1.21 GW!
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added ~1983 for TDMA-40 [5, p.IV-7]
       UPGRADE
@@ -2067,7 +2067,7 @@ skopos_telecom {
       TxPower = 120.828  // 1.21 GW!
       AMWTemp = 80
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added ~1983 for TDMA-40 [5, p.IV-7]
       UPGRADE
@@ -2103,7 +2103,7 @@ skopos_telecom {
       TxPower = 120.828  // 1.21 GW!
       AMWTemp = 80
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added ~1983 for TDMA-40 [5, p.IV-7]
       UPGRADE
@@ -2139,7 +2139,7 @@ skopos_telecom {
       TxPower = 120.828  // 1.21 GW!
       AMWTemp = 80
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added ~1983 for TDMA-40 [5, p.IV-7]
       UPGRADE
@@ -2175,7 +2175,7 @@ skopos_telecom {
       TxPower = 120.828  // 1.21 GW!
       AMWTemp = 80
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added ~1983 for TDMA-40 [5, p.IV-7]
       UPGRADE
@@ -2211,7 +2211,7 @@ skopos_telecom {
       TxPower = 67  // 5 kW same as C-band?
       AMWTemp = 230
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
     }
     //Ground station performance data [4, p.11-16]
@@ -2223,7 +2223,7 @@ skopos_telecom {
       TxPower = 67  // 5 kW Gradient-K transmitter [7] [8]
       AMWTemp = 230
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added ~1983 for TDMA-40 [5, p.IV-7]
       UPGRADE
@@ -2259,7 +2259,7 @@ skopos_telecom {
       TxPower = 65  // Same as C-Band?
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
     }
     //Ground station performance data [4, p.11-16]
@@ -2272,7 +2272,7 @@ skopos_telecom {
       TxPower = 65
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added late 80s for TDMA-40 [5, p.IV-7]
       UPGRADE
@@ -2302,7 +2302,7 @@ skopos_telecom {
       TxPower = 65  // Same as C-Band?
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
     }
     //Ground station performance data [4, p.11-16]
@@ -2315,7 +2315,7 @@ skopos_telecom {
       TxPower = 65
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added late 80s for TDMA-40 [5, p.IV-7]
       UPGRADE
@@ -2345,7 +2345,7 @@ skopos_telecom {
       TxPower = 65  // Same as C-Band?
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
     }
     //Ground station performance data [4, p.11-16]
@@ -2358,7 +2358,7 @@ skopos_telecom {
       TxPower = 65
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added late 80s for TDMA-40 [5, p.IV-7]
       UPGRADE
@@ -2388,7 +2388,7 @@ skopos_telecom {
       TxPower = 65  // Same as C-Band?
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
     }
     //Ground station performance data [4, p.11-16]
@@ -2401,7 +2401,7 @@ skopos_telecom {
       TxPower = 65
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added late 80s for TDMA-40 [5, p.IV-7]
       UPGRADE
@@ -2431,7 +2431,7 @@ skopos_telecom {
       TxPower = 65  // Same as C-Band?
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
     }
     //Ground station performance data [4, p.11-16]
@@ -2444,7 +2444,7 @@ skopos_telecom {
       TxPower = 65
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added late 80s for TDMA-40 [5, p.IV-7]
       UPGRADE
@@ -2474,7 +2474,7 @@ skopos_telecom {
       TxPower = 65  // Same as C-Band?
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
     }
     //Ground station performance data [4, p.11-16]
@@ -2487,7 +2487,7 @@ skopos_telecom {
       TxPower = 65
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added late 80s for TDMA-40 [5, p.IV-7]
       UPGRADE
@@ -2517,7 +2517,7 @@ skopos_telecom {
       TxPower = 65  // Same as C-Band?
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
     }
     //Ground station performance data [4, p.11-16]
@@ -2530,7 +2530,7 @@ skopos_telecom {
       TxPower = 65
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added late 80s for TDMA-40 [5, p.IV-7]
       UPGRADE
@@ -2560,7 +2560,7 @@ skopos_telecom {
       TxPower = 65  // Same as C-Band?
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
     }
     //Ground station performance data [4, p.11-16]
@@ -2573,7 +2573,7 @@ skopos_telecom {
       TxPower = 65
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added late 80s for TDMA-40 [5, p.IV-7]
       UPGRADE
@@ -2603,7 +2603,7 @@ skopos_telecom {
       TxPower = 65  // Same as C-Band?
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
     }
     //Ground station performance data [4, p.11-16]
@@ -2616,7 +2616,7 @@ skopos_telecom {
       TxPower = 65
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added late 80s for TDMA-40 [5, p.IV-7]
       UPGRADE
@@ -2646,7 +2646,7 @@ skopos_telecom {
       TxPower = 65  // Same as C-Band?
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
     }
     //Ground station performance data [4, p.11-16]
@@ -2659,7 +2659,7 @@ skopos_telecom {
       TxPower = 65
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added late 80s for TDMA-40 [5, p.IV-7]
       UPGRADE
@@ -2690,7 +2690,7 @@ skopos_telecom {
       TxPower = 120.828  // 1.21 GW!
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
     }
     Antenna {
@@ -2702,7 +2702,7 @@ skopos_telecom {
       TxPower = 120.828  // 1.21 GW!
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added late 80s for TDMA-40 [5, p.IV-7]
       UPGRADE
@@ -2734,7 +2734,7 @@ skopos_telecom {
       TxPower = 120.828  // 1.21 GW!
       AMWTemp = 150     //from [24]
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
     }
   }
@@ -2758,7 +2758,7 @@ skopos_telecom {
       TxPower = 120.828  // 1.21 GW!
       AMWTemp = 150     //from [24]
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
     }
   }
@@ -2782,7 +2782,7 @@ skopos_telecom {
       TxPower = 120.828  // 1.21 GW!
       AMWTemp = 150     //from [24]
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
     }
   }
@@ -2806,7 +2806,7 @@ skopos_telecom {
       TxPower = 120.828  // 1.21 GW!
       AMWTemp = 150     //from [24]
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
     }
   }
@@ -2830,7 +2830,7 @@ skopos_telecom {
       TxPower = 120.828  // 1.21 GW!
       AMWTemp = 150     //from [24]
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
     }
   }
@@ -2853,7 +2853,7 @@ skopos_telecom {
       TxPower = 65
       AMWTemp = 288
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
     }
   }
@@ -2876,7 +2876,7 @@ skopos_telecom {
       TxPower = 65
       AMWTemp = 288
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
     }
   }
@@ -2905,8 +2905,8 @@ skopos_telecom {
       ModulationBits = 1  //FM, FSK or PSK only?
       EncoderOverride = None - Syncom Voice
       TARGET {}
-	  //If you put off this contract until 1964 tech, you can afford better than Syncom
-	  UPGRADE
+      //If you put off this contract until 1964 tech, you can afford better than Syncom
+      UPGRADE
       {
         TechLevel = 4
         EncoderOverride = None - Early Comsat
@@ -2923,8 +2923,8 @@ skopos_telecom {
       ModulationBits = 1  //FM, FSK or PSK only?
       EncoderOverride = None - Syncom Voice
       TARGET {}
-	  //If you put off this contract until 1964 tech, you can afford better than Syncom
-	  UPGRADE
+      //If you put off this contract until 1964 tech, you can afford better than Syncom
+      UPGRADE
       {
         TechLevel = 4
         EncoderOverride = None - Early Comsat
@@ -2973,10 +2973,10 @@ skopos_telecom {
       TxPower = 57      //500 W?
       AMWTemp = 205
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Syncom Voice
+      EncoderOverride = None - Syncom Voice
       TARGET {}
-	  //If you put off this contract until 1964 tech, you can afford better than Syncom
-	  UPGRADE
+      //If you put off this contract until 1964 tech, you can afford better than Syncom
+      UPGRADE
       {
         TechLevel = 4
         EncoderOverride = None - Early Comsat
@@ -3024,7 +3024,7 @@ skopos_telecom {
       TxPower = 70
       AMWTemp = 135
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
     }
     // Apollo tracking ships also have VHF/UHF voice/command antenna, USB 9-meter antenna, TLM (4-1) 9-meter antenna, TLM (4-2) antenna [9, p.1-7]
@@ -3084,7 +3084,7 @@ skopos_telecom {
       TxPower = 70
       AMWTemp = 135
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
     }
     // Apollo tracking ships also have VHF/UHF voice/command antenna, USB 9-meter antenna, TLM (4-1) 9-meter antenna, TLM (4-2) antenna [9, p.1-7]
@@ -3144,7 +3144,7 @@ skopos_telecom {
       TxPower = 70
       AMWTemp = 135
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
     }
     // Apollo tracking ships also have VHF/UHF voice/command antenna, USB 9-meter antenna, TLM (4-1) 9-meter antenna, TLM (4-2) antenna [9, p.1-7]
@@ -3205,7 +3205,7 @@ skopos_telecom {
       TxPower = 65  // Same as C-Band?
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
     }
     Antenna {
@@ -3217,7 +3217,7 @@ skopos_telecom {
       TxPower = 65
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
     }
     //UHF/VHF setup same as Apollo tracking ships I guess
@@ -3273,7 +3273,7 @@ skopos_telecom {
       TxPower = 65  // Same as C-Band?
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
     }
     Antenna {
@@ -3285,7 +3285,7 @@ skopos_telecom {
       TxPower = 65
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
-	  EncoderOverride = None - Early Comsat
+      EncoderOverride = None - Early Comsat
       TARGET {}
     }
     //UHF/VHF setup same as Apollo tracking ships I guess
@@ -3340,7 +3340,7 @@ skopos_telecom {
       TxPower = 43.5  // 13.5 dbW
       AMWTemp = 562
       ModulationBits = 1  //FM or PSK only
-	  EncoderOverride = None - Early Comsat  //FM voice or PSK CCITT-2 tty [12, p.257]. Data mode might have encoding but [12] doesn't say anything about it.
+      EncoderOverride = None - Early Comsat  //FM voice or PSK CCITT-2 tty [12, p.257]. Data mode might have encoding but [12] doesn't say anything about it.
       TARGET {}
     }
   }
@@ -3362,7 +3362,7 @@ skopos_telecom {
       TxPower = 43.5  // 13.5 dbW
       AMWTemp = 562
       ModulationBits = 1  //FM or PSK only
-	  EncoderOverride = None - Early Comsat  //FM voice or PSK CCITT-2 tty [12, p.257]. Data mode might have encoding but [12] doesn't say anything about it.
+      EncoderOverride = None - Early Comsat  //FM voice or PSK CCITT-2 tty [12, p.257]. Data mode might have encoding but [12] doesn't say anything about it.
       TARGET {}
     }
   }
@@ -3384,7 +3384,7 @@ skopos_telecom {
       TxPower = 43.5  // 13.5 dbW
       AMWTemp = 562
       ModulationBits = 1  //FM or PSK only
-	  EncoderOverride = None - Early Comsat  //FM voice or PSK CCITT-2 tty [12, p.257]. Data mode might have encoding but [12] doesn't say anything about it.
+      EncoderOverride = None - Early Comsat  //FM voice or PSK CCITT-2 tty [12, p.257]. Data mode might have encoding but [12] doesn't say anything about it.
       TARGET {}
     }
   }
@@ -3406,7 +3406,7 @@ skopos_telecom {
       TxPower = 43.5  // 13.5 dbW
       AMWTemp = 562
       ModulationBits = 1  //FM or PSK only
-	  EncoderOverride = None - Early Comsat  //FM voice or PSK CCITT-2 tty [12, p.257]. Data mode might have encoding but [12] doesn't say anything about it.
+      EncoderOverride = None - Early Comsat  //FM voice or PSK CCITT-2 tty [12, p.257]. Data mode might have encoding but [12] doesn't say anything about it.
       TARGET {}
     }
   }
@@ -3429,7 +3429,7 @@ skopos_telecom {
       TxPower = 43.5  // 13.5 dbW
       AMWTemp = 562
       ModulationBits = 1  //FM or PSK only
-	  EncoderOverride = None - Early Comsat  //FM voice or PSK CCITT-2 tty [12, p.257]. Data mode might have encoding but [12] doesn't say anything about it.
+      EncoderOverride = None - Early Comsat  //FM voice or PSK CCITT-2 tty [12, p.257]. Data mode might have encoding but [12] doesn't say anything about it.
       TARGET {}
     }
   }
@@ -3451,7 +3451,7 @@ skopos_telecom {
       TxPower = 43.5  // 13.5 dbW
       AMWTemp = 562
       ModulationBits = 1  //FM or PSK only
-	  EncoderOverride = None - Early Comsat  //FM voice or PSK CCITT-2 tty [12, p.257]. Data mode might have encoding but [12] doesn't say anything about it.
+      EncoderOverride = None - Early Comsat  //FM voice or PSK CCITT-2 tty [12, p.257]. Data mode might have encoding but [12] doesn't say anything about it.
       TARGET {}
     }
   }
@@ -3474,7 +3474,7 @@ skopos_telecom {
       TxPower = 43.5  // 13.5 dbW
       AMWTemp = 562
       ModulationBits = 1  //FM or PSK only
-	  EncoderOverride = None - Early Comsat  //FM voice or PSK CCITT-2 tty [12, p.257]. Data mode might have encoding but [12] doesn't say anything about it.
+      EncoderOverride = None - Early Comsat  //FM voice or PSK CCITT-2 tty [12, p.257]. Data mode might have encoding but [12] doesn't say anything about it.
       TARGET {}
     }
   }
@@ -3496,7 +3496,7 @@ skopos_telecom {
       TxPower = 43.5  // 13.5 dbW
       AMWTemp = 562
       ModulationBits = 1  //FM or PSK only
-	  EncoderOverride = None - Early Comsat  //FM voice or PSK CCITT-2 tty [12, p.257]. Data mode might have encoding but [12] doesn't say anything about it.
+      EncoderOverride = None - Early Comsat  //FM voice or PSK CCITT-2 tty [12, p.257]. Data mode might have encoding but [12] doesn't say anything about it.
       TARGET {}
     }
   }
@@ -3518,7 +3518,7 @@ skopos_telecom {
       TxPower = 43.5  // 13.5 dbW
       AMWTemp = 562
       ModulationBits = 1  //FM or PSK only
-	  EncoderOverride = None - Early Comsat  //FM voice or PSK CCITT-2 tty [12, p.257]. Data mode might have encoding but [12] doesn't say anything about it.
+      EncoderOverride = None - Early Comsat  //FM voice or PSK CCITT-2 tty [12, p.257]. Data mode might have encoding but [12] doesn't say anything about it.
       TARGET {}
     }
   }
@@ -3540,7 +3540,7 @@ skopos_telecom {
       TxPower = 43.5  // 13.5 dbW
       AMWTemp = 562
       ModulationBits = 1  //FM or PSK only
-	  EncoderOverride = None - Early Comsat  //FM voice or PSK CCITT-2 tty [12, p.257]. Data mode might have encoding but [12] doesn't say anything about it.
+      EncoderOverride = None - Early Comsat  //FM voice or PSK CCITT-2 tty [12, p.257]. Data mode might have encoding but [12] doesn't say anything about it.
       TARGET {}
     }
   }
@@ -3562,7 +3562,7 @@ skopos_telecom {
       TxPower = 43.5  // 13.5 dbW
       AMWTemp = 562
       ModulationBits = 1  //FM or PSK only
-	  EncoderOverride = None - Early Comsat  //FM voice or PSK CCITT-2 tty [12, p.257]. Data mode might have encoding but [12] doesn't say anything about it.
+      EncoderOverride = None - Early Comsat  //FM voice or PSK CCITT-2 tty [12, p.257]. Data mode might have encoding but [12] doesn't say anything about it.
       TARGET {}
     }
   }
@@ -3584,7 +3584,7 @@ skopos_telecom {
       TxPower = 43.5  // 13.5 dbW
       AMWTemp = 562
       ModulationBits = 1  //FM or PSK only
-	  EncoderOverride = None - Early Comsat  //FM voice or PSK CCITT-2 tty [12, p.257]. Data mode might have encoding but [12] doesn't say anything about it.
+      EncoderOverride = None - Early Comsat  //FM voice or PSK CCITT-2 tty [12, p.257]. Data mode might have encoding but [12] doesn't say anything about it.
       TARGET {}
     }
   }
@@ -3606,7 +3606,7 @@ skopos_telecom {
       TxPower = 43.5  // 13.5 dbW
       AMWTemp = 562
       ModulationBits = 1  //FM or PSK only
-	  EncoderOverride = None - Early Comsat  //FM voice or PSK CCITT-2 tty [12, p.257]. Data mode might have encoding but [12] doesn't say anything about it.
+      EncoderOverride = None - Early Comsat  //FM voice or PSK CCITT-2 tty [12, p.257]. Data mode might have encoding but [12] doesn't say anything about it.
       TARGET {}
     }
   }
@@ -3628,7 +3628,7 @@ skopos_telecom {
       TxPower = 43.5  // 13.5 dbW
       AMWTemp = 562
       ModulationBits = 1  //FM or PSK only
-	  EncoderOverride = None - Early Comsat  //FM voice or PSK CCITT-2 tty [12, p.257]. Data mode might have encoding but [12] doesn't say anything about it.
+      EncoderOverride = None - Early Comsat  //FM voice or PSK CCITT-2 tty [12, p.257]. Data mode might have encoding but [12] doesn't say anything about it.
       TARGET {}
     }
   }

--- a/GameData/Skopos/telecom.cfg
+++ b/GameData/Skopos/telecom.cfg
@@ -7,12 +7,10 @@
     // Using MARISAT as basis, downlink at 1.535 GHz and uplink at 1.660 GHz
     // Put allocation in the middle
     Frequency = 1.5975e9
-    //192 MHz so we get the same rate halvings as C-Band, comparable to ~200 MHz available to Molniya
-    ChannelWidth = 192e6
+    //128 MHz so we get the same rate halvings as C-Band, comparable to ~200 MHz available to Molniya
+    ChannelWidth = 128e6
   }
-}
 
-@RealAntennasCommNetParams:AFTER[RealAntennas] {
   BandInfo {
     name = C (Wideband)
     TechLevel = 3
@@ -21,24 +19,53 @@
     // We should not allow more than 2 GHz (half the band); RA does not separate
     // uplink and downlink, the downlink would usually be in the 4 GHz range and
     // the uplink in the 6 GHz range.
-    // The value 1.536 GHz is chosen as 256 times the width of an NTSC channel,
-    // so that a single TV channel is within the reach of the halvings allowed
-    // at Tech Level 3.
-    // For comparison, the Telstar 400s had 24 C band transponders of 36 MHz
-    // each, for a total of 864 MHz.
-    ChannelWidth = 1.536e9
+
+    //Standard ITU C-band fixed satellite service allocations. 500 MHz uplink, 500 MHz downlink. [32, p.4]
+	//make it 1024 so rate halvings divide evenly
+    ChannelWidth = 1.024e9
+  }
+
+  BandInfo {
+    name = Ku (Wideband)
+    TechLevel = 6
+    // Put the allocation just at 12 GHz.
+    Frequency = 11.95e9
+    // ITU allocates US downlink between 11.70-12.20 GHz, and uplink between 14.0-14.5 GHz
+
+    //Standard ITU Ku-band fixed satellite service allocations. 500 MHz uplink, 500 MHz downlink. [32, p.4]
+	//make it 1024 so rate halvings divide evenly
+    ChannelWidth = 1.024e9
   }
 }
 
 @RealAntennasCommNetParams:AFTER[RealAntennas] {
-  BandInfo {
-    name = Ku (Wideband)
-    TechLevel = 6
-    // Put the allocation just above 12 GHz.
-    Frequency = 12.6e9
-    // ITU allocates downlink between 10.75-12.75 GHz, and uplink between 14-14.5 GHz (depending on region)
-    // Frequency allocation broadly the same as C-band at 500 MHz wide for fixed satellite service.
-    ChannelWidth = 1.536e9
+  EncoderInfo
+  {
+    name = None - Syncom Voice
+    // Syncom voice FMFB reciever threshold at 6 db C/N [4, p.8-6]. Pretty bad (>1e-3 BER), but enough for voice. Mostly just for Kingsport because it is extremely marginal with Syncom.
+    TechLevel = -1
+    CodingRate = 1
+    RequiredEbN0 = 6
+  }
+  EncoderInfo
+  {
+    name = None - Early Comsat
+    // 10 db C/N pretty standard for most commsats operating with analog channels. BER ~1e-5, enough for analog TV, voice, facsimile, etc.
+    // In reality this was the bare minimum when operating at full bandwidth (voice). Actual error-sensitive applications (TV and data) would
+    // dump all the channel power into a narrower (~6 MHz for TV) channel to improve C/N and reduce error rate
+    // Since we're just using this to simulate analog within RA's digital system, just ask for the entire channel at the bare minimum error rate
+    // (using digital data rate to set analog channel width).
+    TechLevel = -1
+    CodingRate = 1
+    RequiredEbN0 = 6
+  }
+  EncoderInfo
+  {
+    name = None - 70s Comsat
+    //11.4 db C/N for a BER of ~1e-7 in SPADE BPSK mode [31, p.9]. Intelsat standard from Intelsat IV to digital era.
+    TechLevel = -1
+    CodingRate = 1
+    RequiredEbN0 = 11.4
   }
 }
 
@@ -66,8 +93,9 @@ skopos_telecom {
       referenceGain = 58        //same antenna as C-band, just operating in L-band
       referenceFrequency = 4768
       TxPower = 63      // 2 kW.
-      AMWTemp = 230     //Based on Syncom AN/FSC-9 terminals [4, p.8-10]
+      AMWTemp = 214     //230K-16K. Based on Syncom AN/FSC-9 terminals [4, p.8-10]. -16K for RA atmo noise
       ModulationBits = 1  //FM, FSK or PSK only?
+      EncoderOverride = None - Early Comsat
       TARGET {}
     }
     Antenna {
@@ -79,6 +107,7 @@ skopos_telecom {
       TxPower = 63  // 2 kW.
       AMWTemp = 32
       ModulationBits = 1  //FM, FSK or PSK only?
+      EncoderOverride = None - Early Comsat
       TARGET {}
       //Modified 1964 in preparation for Early Bird [4, p.10-43]
       UPGRADE
@@ -114,35 +143,28 @@ skopos_telecom {
     lon = -119.11629128719811
     alt = 50
     role = trx
-    //Ground station performance data [4]
-    //L-band for Relay and Syncom
-    //Using stats from Mojave Terminal [4, p.7-8]
+    //L-band for Syncom [33, p.129]
     Antenna {
       TechLevel = 3
       RFBand = L (Wideband)
-      referenceGain = 49.1
-      referenceFrequency = 1597.5
-      TxPower = 70      // 10 kW.
-      AMWTemp = 360
+      referenceGain = 51.5  //85 ft antenna gain at 1814 MHz [33, p.142]
+      referenceFrequency = 1814
+      TxPower = 59.5   //Using Mojave transmitter [4, p.7-8]. Correct for EIRP: 111 dbm-51.5 dbi = 59.5 dbm
+      AMWTemp = 30    //37.7K @ 15 degrees, ~30K at zenith [33, p.132]
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
     }
+    //85 ft antenna operating in C-band (ahistorical, but filling in for various other Califonia stations)
     Antenna {
       TechLevel = 3
       RFBand = C (Wideband)
-      // Gain of the 85 ft UHF dish from NASA TR R-252, p. 125.
-      // [OH64] give this as 51.2 instead.
-      // Note that we change this to C band.
-      referenceGain = 51.5
+      referenceGain = 59.5    //85 ft antenna, assume 55% efficiency in C-band (same as early bird terminals)
       referenceFrequency = 4768
-      // Power of the Mojave UHF transmitter from NASA SP-76, p. 362.
-      // We conflate Mojave (Trx in Relay and ATS) and point Mugu (Rx in
-      // Syncom), it’s not like the 130 km make a difference.
-      TxPower = 70  // 10 kW.
-      // Temperature of the UHF receiving system.
-      // 40 K in [OH64].
-      AMWTemp = 38
+      TxPower = 65  // same as early bird terminals [4, p.10-43]
+      AMWTemp = 50  // same as early bird terminals [4, p.10-43]
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added ~1985 for Intelsat V? [5, p.IV-7]
       UPGRADE
@@ -176,6 +198,7 @@ skopos_telecom {
       TxPower = 63  // 2 kW.
       AMWTemp = 75
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK modem added 1966 for ATS-1/3 testing [4, p.13-10]
       UPGRADE
@@ -199,6 +222,7 @@ skopos_telecom {
       TxPower = 60  // 1 kW. Actually transmitted at 31.65 GHz?
       AMWTemp = 1000
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
     }
   }
@@ -220,6 +244,7 @@ skopos_telecom {
       TxPower = 70  // 10 kW.
       AMWTemp = 50
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added ~1985 for Intelsat V? [5, p.IV-7]
       UPGRADE
@@ -253,6 +278,7 @@ skopos_telecom {
       TxPower = 67.8  //6 kW
       AMWTemp = 50
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added ~1985 for Intelsat V? [5, p.IV-7]
       UPGRADE
@@ -286,6 +312,7 @@ skopos_telecom {
       TxPower = 67.8  //6 kW
       AMWTemp = 50
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added ~1985 for Intelsat V? [5, p.IV-7]
       UPGRADE
@@ -320,6 +347,7 @@ skopos_telecom {
       TxPower = 65
       AMWTemp = 120
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - 70s Comsat
       TARGET {}
     }
     //Ground station performance data [12, p.252]
@@ -331,6 +359,7 @@ skopos_telecom {
       TxPower = 65
       AMWTemp = 288
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - 70s Comsat
       TARGET {}
     }
   }
@@ -352,6 +381,7 @@ skopos_telecom {
       TxPower = 65
       AMWTemp = 288
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - 70s Comsat
       TARGET {}
     }
   }
@@ -374,6 +404,7 @@ skopos_telecom {
       TxPower = 65  //3 kW
       AMWTemp = 56
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - 70s Comsat
       TARGET {}
     }
     //Using 5-meter SBS Ku-band antenna at WD 44 Franklin Lakes as basis for commercial Ku-band stations [6, p.88]
@@ -381,10 +412,11 @@ skopos_telecom {
       TechLevel = 7     //first SBS antennas deployed by 1978, SBS 1 launched 1980.
       RFBand = Ku (Wideband)
       referenceGain = 53.9
-      referenceFrequency = 12600
+      referenceFrequency = 11950
       TxPower = 65
       AMWTemp = 225
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - 70s Comsat
       TARGET {}
     }
   }
@@ -406,6 +438,7 @@ skopos_telecom {
       TxPower = 65  //3 kW
       AMWTemp = 78
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - 70s Comsat
       TARGET {}
     }
     //Using 5-meter SBS Ku-band antenna at WD 44 Franklin Lakes as basis for commercial Ku-band stations [6, p.88]
@@ -413,10 +446,11 @@ skopos_telecom {
       TechLevel = 7     //first SBS antennas deployed by 1978, SBS 1 launched 1980.
       RFBand = Ku (Wideband)
       referenceGain = 53.9
-      referenceFrequency = 12600
+      referenceFrequency = 11950
       TxPower = 65
       AMWTemp = 225
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - 70s Comsat
       TARGET {}
     }
   }
@@ -438,6 +472,7 @@ skopos_telecom {
       TxPower = 61  //1.5 kW
       AMWTemp = 85
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - 70s Comsat
       TARGET {}
     }
     //Using 5-meter SBS Ku-band antenna at WD 44 Franklin Lakes as basis for commercial Ku-band stations [6, p.88]
@@ -445,10 +480,11 @@ skopos_telecom {
       TechLevel = 7     //first SBS antennas deployed by 1978, SBS 1 launched 1980.
       RFBand = Ku (Wideband)
       referenceGain = 53.9
-      referenceFrequency = 12600
+      referenceFrequency = 11950
       TxPower = 65
       AMWTemp = 225
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - 70s Comsat
       TARGET {}
     }
   }
@@ -470,6 +506,7 @@ skopos_telecom {
       TxPower = 65  //3 kW
       AMWTemp = 112
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - 70s Comsat
       TARGET {}
     }
     //Using 5-meter SBS Ku-band antenna at WD 44 Franklin Lakes as basis for commercial Ku-band stations [6, p.88]
@@ -477,10 +514,11 @@ skopos_telecom {
       TechLevel = 7     //first SBS antennas deployed by 1978, SBS 1 launched 1980.
       RFBand = Ku (Wideband)
       referenceGain = 53.9
-      referenceFrequency = 12600
+      referenceFrequency = 11950
       TxPower = 65
       AMWTemp = 225
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - 70s Comsat
       TARGET {}
     }
   }
@@ -502,6 +540,7 @@ skopos_telecom {
       TxPower = 61  //1.5 kW
       AMWTemp = 85
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - 70s Comsat
       TARGET {}
     }
     //Using 5-meter SBS Ku-band antenna at WD 44 Franklin Lakes as basis for commercial Ku-band stations [6, p.88]
@@ -509,10 +548,11 @@ skopos_telecom {
       TechLevel = 7     //first SBS antennas deployed by 1978, SBS 1 launched 1980.
       RFBand = Ku (Wideband)
       referenceGain = 53.9
-      referenceFrequency = 12600
+      referenceFrequency = 11950
       TxPower = 65
       AMWTemp = 225
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - 70s Comsat
       TARGET {}
     }
   }
@@ -534,6 +574,7 @@ skopos_telecom {
       TxPower = 61  //1.5 kW
       AMWTemp = 85
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - 70s Comsat
       TARGET {}
     }
     //Using 5-meter SBS Ku-band antenna at WD 44 Franklin Lakes as basis for commercial Ku-band stations [6, p.88]
@@ -541,10 +582,11 @@ skopos_telecom {
       TechLevel = 7     //first SBS antennas deployed by 1978, SBS 1 launched 1980.
       RFBand = Ku (Wideband)
       referenceGain = 53.9
-      referenceFrequency = 12600
+      referenceFrequency = 11950
       TxPower = 65
       AMWTemp = 225
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - 70s Comsat
       TARGET {}
     }
   }
@@ -566,6 +608,7 @@ skopos_telecom {
       TxPower = 64.8  //3 kW
       AMWTemp = 22
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - 70s Comsat
       TARGET {}
     }
     //Using 5-meter SBS Ku-band antenna at WD 44 Franklin Lakes as basis for commercial Ku-band stations [6, p.88]
@@ -573,10 +616,11 @@ skopos_telecom {
       TechLevel = 7     //first SBS antennas deployed by 1978, SBS 1 launched 1980.
       RFBand = Ku (Wideband)
       referenceGain = 53.9
-      referenceFrequency = 12600
+      referenceFrequency = 11950
       TxPower = 65
       AMWTemp = 225
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - 70s Comsat
       TARGET {}
     }
   }
@@ -598,6 +642,7 @@ skopos_telecom {
       TxPower = 65  //3 kW
       AMWTemp = 630
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
     }
     //Using 5-meter SBS Ku-band antenna at WD 44 Franklin Lakes as basis for commercial Ku-band stations [6, p.88]
@@ -605,10 +650,11 @@ skopos_telecom {
       TechLevel = 7     //first SBS antennas deployed by 1978, SBS 1 launched 1980.
       RFBand = Ku (Wideband)
       referenceGain = 53.9
-      referenceFrequency = 12600
+      referenceFrequency = 11950
       TxPower = 65
       AMWTemp = 225
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - 70s Comsat
       TARGET {}
     }
   }
@@ -630,6 +676,7 @@ skopos_telecom {
       TxPower = 65  //3 kW
       AMWTemp = 78
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
     }
     //Using 5-meter SBS Ku-band antenna at WD 44 Franklin Lakes as basis for commercial Ku-band stations [6, p.88]
@@ -637,10 +684,11 @@ skopos_telecom {
       TechLevel = 7     //first SBS antennas deployed by 1978, SBS 1 launched 1980.
       RFBand = Ku (Wideband)
       referenceGain = 53.9
-      referenceFrequency = 12600
+      referenceFrequency = 11950
       TxPower = 65
       AMWTemp = 225
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - 70s Comsat
       TARGET {}
     }
   }
@@ -663,6 +711,7 @@ skopos_telecom {
       TxPower = 65      //3 kW
       AMWTemp = 150
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
     }
     //I don't know if the CTS Ku-band terminal was actually at Allan Park, but it should be close enough [4, p.19-16]
@@ -670,10 +719,11 @@ skopos_telecom {
       TechLevel = 6
       RFBand = Ku (Wideband)
       referenceGain = 57
-      referenceFrequency = 12600
+      referenceFrequency = 11950
       TxPower = 53      //200 W
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - 70s Comsat
       TARGET {}
     }
   }
@@ -695,6 +745,7 @@ skopos_telecom {
       TxPower = 65      //3 kW
       AMWTemp = 150
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - 70s Comsat
       TARGET {}
     }
   }
@@ -716,6 +767,7 @@ skopos_telecom {
       TxPower = 65      //3 kW
       AMWTemp = 150
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - 70s Comsat
       TARGET {}
     }
   }
@@ -737,6 +789,7 @@ skopos_telecom {
       TxPower = 65      //3 kW
       AMWTemp = 150
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - 70s Comsat
       TARGET {}
     }
   }
@@ -758,6 +811,7 @@ skopos_telecom {
       TxPower = 65      //3 kW
       AMWTemp = 150
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - 70s Comsat
       TARGET {}
     }
   }
@@ -776,10 +830,11 @@ skopos_telecom {
       TechLevel = 6
       RFBand = Ku (Wideband)
       referenceGain = 47
-      referenceFrequency = 12600
+      referenceFrequency = 11950
       TxPower = 43      //20 W
       AMWTemp = 670
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - 70s Comsat
       TARGET {}
     }
   }
@@ -804,6 +859,7 @@ skopos_telecom {
       TxPower = 120.828  // 1.21 GW!
       AMWTemp = 205
       ModulationBits = 2  //ASC recieve-only terminals could operate in QPSK
+	  EncoderOverride = None - 70s Comsat
       TARGET {}
     }
   }
@@ -827,6 +883,7 @@ skopos_telecom {
       TxPower = 70  //typical of second generation earth stations [4, p.10-44]
       AMWTemp = 58  //typical of second generation earth stations [4, p.10-44]
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added ~1985 for Intelsat V? [5, p.IV-7]
       UPGRADE
@@ -858,7 +915,8 @@ skopos_telecom {
       referenceFrequency = 4768
       TxPower = 63
       AMWTemp = 220
-      ModulationBits = 1  //FM, FSK or PSK only?
+      ModulationBits = 1  //FM, FSK or PSK only?.
+	  EncoderOverride = None - Early Comsat
       TARGET {}
       UPGRADE
       {
@@ -902,6 +960,7 @@ skopos_telecom {
       TxPower = 70  //10 kW
       AMWTemp = 58
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added ~1985 for Intelsat V? [5, p.IV-7]
       UPGRADE
@@ -935,8 +994,9 @@ skopos_telecom {
       referenceGain = 58        //same antenna as C-band, just operating in L-band
       referenceFrequency = 4768
       TxPower = 63      // 2 kW.
-      AMWTemp = 230     //Based on Syncom AN/FSC-9 terminals [4, p.8-10]
+      AMWTemp = 214     //230K-16K. Based on Syncom AN/FSC-9 terminals [4, p.8-10]. -16K for RA atmo noise
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
     }
     Antenna {
@@ -948,6 +1008,7 @@ skopos_telecom {
       TxPower = 63  // 2 kW.
       AMWTemp = 32
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
       //Modified 1964 in preparation for Early Bird [4, p.10-43]
       UPGRADE
@@ -992,8 +1053,9 @@ skopos_telecom {
       referenceGain = 55.6
       referenceFrequency = 4768
       TxPower = 63      // 2 kW?
-      AMWTemp = 230     //Based on Syncom AN/FSC-9 terminals [4, p.8-10]
+      AMWTemp = 214     //230K-16K. Based on Syncom AN/FSC-9 terminals [4, p.8-10]. -16K for RA atmo noise
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
     }
     //original telstar performance [4, p.6-9]
@@ -1005,6 +1067,7 @@ skopos_telecom {
       TxPower = 67  // 5 kW.
       AMWTemp = 55
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
       //Goonhilly modified in 1964 to correct poor performance in preparation for Early Bird [4, p.10-43]
       UPGRADE
@@ -1045,6 +1108,7 @@ skopos_telecom {
       TxPower = 63
       AMWTemp = 220
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
       //Raisting modified in 1964 for Relay 2 [4, p.7-8]
       //Raisting modified in 1965 in preparation for Early Bird [4, p.10-43]
@@ -1086,6 +1150,7 @@ skopos_telecom {
       TxPower = 63    //2 kW
       AMWTemp = 220
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
       UPGRADE
       {
@@ -1124,30 +1189,29 @@ skopos_telecom {
     lon = 140.6601046239096
     alt = 50
     role = trx
-    //Ground station performance data [4]
-    //L-band for Relay and Syncom
+    //L-band for Syncom [33, p.125]
+	//transmitting from 10 m antenna, recieving from 30 m antenna
     Antenna {
       TechLevel = 3
-      RFBand = L (Wideband)     //just let RA autocalculate gain
-      referenceGain = 48        //same antenna as C-band, just operating in L-band
-      referenceFrequency = 4768
-      TxPower = 70      // 10 kW.
-      AMWTemp = 230     //Based on Syncom AN/FSC-9 terminals [4, p.8-10]
+      RFBand = L (Wideband)
+      referenceGain = 51.5    //51.5 db at 1812 MHz
+      referenceFrequency = 1812
+      TxPower = 73.5  // actually transmitting in X-band. Correct for EIRP: 125 dbm - 51.5 dbi = 73.5 dbm
+      AMWTemp = 60    // no elevation given
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
     }
+    //10 m antenna operating in C-band (ahistorical, but filling in for various other Japanese stations)
     Antenna {
       TechLevel = 3
       RFBand = C (Wideband)
-      // Gain of the 10 m transmitter dish from NASA TR R-252, p. 125.
-      // The downlink used a 30 m UHF dish, but we ignore that.
-      referenceGain = 55.0
+      referenceGain = 51.3  //10 m antenna, assume 55% efficiency in C-band (same as early bird terminals)
       referenceFrequency = 4768
-      TxPower = 70  // 10 kW.
-      // Temperature of the UHF receiving system.
-      // 75 K in [OH64].
-      AMWTemp = 60
+      TxPower = 73.7  // actually transmitting in X-band. Correct for EIRP: 125 dbm - 51.3 dbi = 73.5 dbm
+      AMWTemp = 60    // same as L-band?
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
       //98.5ft antenna installed 1967 for ATS-1/3 [4, p.13-5]
       UPGRADE
@@ -1187,6 +1251,7 @@ skopos_telecom {
       TxPower = 70  //typical of second generation earth stations [4, p.10-44]
       AMWTemp = 58  //typical of second generation earth stations [4, p.10-44]
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added ~1985 for Intelsat V? [5, p.IV-7]
       UPGRADE
@@ -1220,6 +1285,7 @@ skopos_telecom {
       TxPower = 70  //typical of second generation earth stations [4, p.10-44]
       AMWTemp = 58  //typical of second generation earth stations [4, p.10-44]
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added ~1985 for Intelsat V? [5, p.IV-7]
       UPGRADE
@@ -1252,6 +1318,7 @@ skopos_telecom {
       TxPower = 70  //typical of second generation earth stations [4, p.10-44]
       AMWTemp = 58  //typical of second generation earth stations [4, p.10-44]
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
       //Upgraded for Intelsat III in 1970 [4, p.10-17]
       //Upgraded to what not specified, but several 97 ft antennas are present there today
@@ -1293,6 +1360,7 @@ skopos_telecom {
       TxPower = 70  //typical of second generation earth stations [4, p.10-44]
       AMWTemp = 58  //typical of second generation earth stations [4, p.10-44]
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added ~1985 for Intelsat V? [5, p.IV-7]
       UPGRADE
@@ -1326,6 +1394,7 @@ skopos_telecom {
       TxPower = 70  //typical of second generation earth stations
       AMWTemp = 58  //typical of second generation earth stations
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added ~1985 for Intelsat V? [5, p.IV-7]
       UPGRADE
@@ -1364,6 +1433,7 @@ skopos_telecom {
       TxPower = 63  // 2 kW.
       AMWTemp = 33
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
       //97ft antenna installed 1969 [4, p.10-16]
       UPGRADE
@@ -1394,7 +1464,7 @@ skopos_telecom {
     // ground.
     alt = 557
     role = trx
-    //Ground station performance data [4, p.13-6]
+    //Ground station performance data [4, p.13-16]
     Antenna {
       TechLevel = 3
       RFBand = C (Wideband)
@@ -1403,6 +1473,7 @@ skopos_telecom {
       TxPower = 63  // 2 kW.
       AMWTemp = 75
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
       //Moree brought online 1968 with 92ft antenna [4, p.10-14]
       //Since it's close(ish) to Cooby Creek, just add to Cooby Creek
@@ -1597,6 +1668,7 @@ skopos_telecom {
       TxPower = 70  //typical of second generation earth stations
       AMWTemp = 58  //typical of second generation earth stations
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added ~1985 for Intelsat V? [5, p.IV-7]
       UPGRADE
@@ -1632,6 +1704,7 @@ skopos_telecom {
       TxPower = 67  // 5 kW same as C-band?
       AMWTemp = 230
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
     }
     //Ground station performance data [4, p.11-16]
@@ -1643,6 +1716,7 @@ skopos_telecom {
       TxPower = 67  // 5 kW Gradient-K transmitter [7] [8]
       AMWTemp = 230
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
       //Moscow has a standard Intelsat terminal installed 1974 [4, p.10-20]
       UPGRADE
@@ -1671,10 +1745,11 @@ skopos_telecom {
       TechLevel = 6
       RFBand = Ku (Wideband)
       referenceGain = 59.3
-      referenceFrequency = 12600
+      referenceFrequency = 11950
       TxPower = 62  //1.5 kW
       AMWTemp = 537
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
     }
   }
@@ -1695,6 +1770,7 @@ skopos_telecom {
       TxPower = 67  // 5 kW same as C-band?
       AMWTemp = 230
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
     }
     //Ground station performance data [4, p.11-16]
@@ -1706,6 +1782,7 @@ skopos_telecom {
       TxPower = 67  // 5 kW Gradient-K transmitter [7] [8]
       AMWTemp = 230
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added ~1983 for TDMA-40 [5, p.IV-7]
       UPGRADE
@@ -1725,10 +1802,11 @@ skopos_telecom {
       TechLevel = 6
       RFBand = Ku (Wideband)
       referenceGain = 59.3
-      referenceFrequency = 12600
+      referenceFrequency = 11950
       TxPower = 62  //1.5 kW
       AMWTemp = 537
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
     }
   }
@@ -1749,6 +1827,7 @@ skopos_telecom {
       TxPower = 65  // Same as C-Band?
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
     }
     //Ground station performance data [4, p.11-16]
@@ -1761,6 +1840,7 @@ skopos_telecom {
       TxPower = 65
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added ~1983 for TDMA-40 [5, p.IV-7]
       UPGRADE
@@ -1795,6 +1875,7 @@ skopos_telecom {
       TxPower = 120.828  // 1.21 GW!
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
     }
     //Ground station performance data [4, p.11-16]
@@ -1807,6 +1888,7 @@ skopos_telecom {
       TxPower = 120.828  // 1.21 GW!
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added ~1983 for TDMA-40 [5, p.IV-7]
       UPGRADE
@@ -1841,6 +1923,7 @@ skopos_telecom {
       TxPower = 120.828  // 1.21 GW!
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
     }
     //Ground station performance data [4, p.11-16]
@@ -1853,6 +1936,7 @@ skopos_telecom {
       TxPower = 120.828  // 1.21 GW!
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added ~1983 for TDMA-40 [5, p.IV-7]
       UPGRADE
@@ -1886,6 +1970,7 @@ skopos_telecom {
       TxPower = 65  // Same as C-Band?
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
     }
     //Ground station performance data [4, p.11-16]
@@ -1898,6 +1983,7 @@ skopos_telecom {
       TxPower = 65
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added ~1983 for TDMA-40 [5, p.IV-7]
       UPGRADE
@@ -1932,6 +2018,7 @@ skopos_telecom {
       TxPower = 120.828  // 1.21 GW!
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
     }
     //Ground station performance data [4, p.11-16]
@@ -1944,6 +2031,7 @@ skopos_telecom {
       TxPower = 120.828  // 1.21 GW!
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added ~1983 for TDMA-40 [5, p.IV-7]
       UPGRADE
@@ -1979,6 +2067,7 @@ skopos_telecom {
       TxPower = 120.828  // 1.21 GW!
       AMWTemp = 80
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added ~1983 for TDMA-40 [5, p.IV-7]
       UPGRADE
@@ -2014,6 +2103,7 @@ skopos_telecom {
       TxPower = 120.828  // 1.21 GW!
       AMWTemp = 80
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added ~1983 for TDMA-40 [5, p.IV-7]
       UPGRADE
@@ -2049,6 +2139,7 @@ skopos_telecom {
       TxPower = 120.828  // 1.21 GW!
       AMWTemp = 80
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added ~1983 for TDMA-40 [5, p.IV-7]
       UPGRADE
@@ -2084,6 +2175,7 @@ skopos_telecom {
       TxPower = 120.828  // 1.21 GW!
       AMWTemp = 80
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added ~1983 for TDMA-40 [5, p.IV-7]
       UPGRADE
@@ -2119,6 +2211,7 @@ skopos_telecom {
       TxPower = 67  // 5 kW same as C-band?
       AMWTemp = 230
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
     }
     //Ground station performance data [4, p.11-16]
@@ -2130,6 +2223,7 @@ skopos_telecom {
       TxPower = 67  // 5 kW Gradient-K transmitter [7] [8]
       AMWTemp = 230
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added ~1983 for TDMA-40 [5, p.IV-7]
       UPGRADE
@@ -2165,6 +2259,7 @@ skopos_telecom {
       TxPower = 65  // Same as C-Band?
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
     }
     //Ground station performance data [4, p.11-16]
@@ -2177,6 +2272,7 @@ skopos_telecom {
       TxPower = 65
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added late 80s for TDMA-40 [5, p.IV-7]
       UPGRADE
@@ -2206,6 +2302,7 @@ skopos_telecom {
       TxPower = 65  // Same as C-Band?
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
     }
     //Ground station performance data [4, p.11-16]
@@ -2218,6 +2315,7 @@ skopos_telecom {
       TxPower = 65
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added late 80s for TDMA-40 [5, p.IV-7]
       UPGRADE
@@ -2247,6 +2345,7 @@ skopos_telecom {
       TxPower = 65  // Same as C-Band?
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
     }
     //Ground station performance data [4, p.11-16]
@@ -2259,6 +2358,7 @@ skopos_telecom {
       TxPower = 65
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added late 80s for TDMA-40 [5, p.IV-7]
       UPGRADE
@@ -2288,6 +2388,7 @@ skopos_telecom {
       TxPower = 65  // Same as C-Band?
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
     }
     //Ground station performance data [4, p.11-16]
@@ -2300,6 +2401,7 @@ skopos_telecom {
       TxPower = 65
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added late 80s for TDMA-40 [5, p.IV-7]
       UPGRADE
@@ -2329,6 +2431,7 @@ skopos_telecom {
       TxPower = 65  // Same as C-Band?
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
     }
     //Ground station performance data [4, p.11-16]
@@ -2341,6 +2444,7 @@ skopos_telecom {
       TxPower = 65
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added late 80s for TDMA-40 [5, p.IV-7]
       UPGRADE
@@ -2370,6 +2474,7 @@ skopos_telecom {
       TxPower = 65  // Same as C-Band?
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
     }
     //Ground station performance data [4, p.11-16]
@@ -2382,6 +2487,7 @@ skopos_telecom {
       TxPower = 65
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added late 80s for TDMA-40 [5, p.IV-7]
       UPGRADE
@@ -2411,6 +2517,7 @@ skopos_telecom {
       TxPower = 65  // Same as C-Band?
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
     }
     //Ground station performance data [4, p.11-16]
@@ -2423,6 +2530,7 @@ skopos_telecom {
       TxPower = 65
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added late 80s for TDMA-40 [5, p.IV-7]
       UPGRADE
@@ -2452,6 +2560,7 @@ skopos_telecom {
       TxPower = 65  // Same as C-Band?
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
     }
     //Ground station performance data [4, p.11-16]
@@ -2464,6 +2573,7 @@ skopos_telecom {
       TxPower = 65
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added late 80s for TDMA-40 [5, p.IV-7]
       UPGRADE
@@ -2493,6 +2603,7 @@ skopos_telecom {
       TxPower = 65  // Same as C-Band?
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
     }
     //Ground station performance data [4, p.11-16]
@@ -2505,6 +2616,7 @@ skopos_telecom {
       TxPower = 65
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added late 80s for TDMA-40 [5, p.IV-7]
       UPGRADE
@@ -2534,6 +2646,7 @@ skopos_telecom {
       TxPower = 65  // Same as C-Band?
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
     }
     //Ground station performance data [4, p.11-16]
@@ -2546,6 +2659,7 @@ skopos_telecom {
       TxPower = 65
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added late 80s for TDMA-40 [5, p.IV-7]
       UPGRADE
@@ -2576,6 +2690,7 @@ skopos_telecom {
       TxPower = 120.828  // 1.21 GW!
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
     }
     Antenna {
@@ -2587,6 +2702,7 @@ skopos_telecom {
       TxPower = 120.828  // 1.21 GW!
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
       // QPSK capability added late 80s for TDMA-40 [5, p.IV-7]
       UPGRADE
@@ -2618,6 +2734,7 @@ skopos_telecom {
       TxPower = 120.828  // 1.21 GW!
       AMWTemp = 150     //from [24]
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
     }
   }
@@ -2641,6 +2758,7 @@ skopos_telecom {
       TxPower = 120.828  // 1.21 GW!
       AMWTemp = 150     //from [24]
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
     }
   }
@@ -2664,6 +2782,7 @@ skopos_telecom {
       TxPower = 120.828  // 1.21 GW!
       AMWTemp = 150     //from [24]
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
     }
   }
@@ -2687,6 +2806,7 @@ skopos_telecom {
       TxPower = 120.828  // 1.21 GW!
       AMWTemp = 150     //from [24]
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
     }
   }
@@ -2710,6 +2830,7 @@ skopos_telecom {
       TxPower = 120.828  // 1.21 GW!
       AMWTemp = 150     //from [24]
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
     }
   }
@@ -2732,6 +2853,7 @@ skopos_telecom {
       TxPower = 65
       AMWTemp = 288
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
     }
   }
@@ -2754,6 +2876,7 @@ skopos_telecom {
       TxPower = 65
       AMWTemp = 288
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
     }
   }
@@ -2780,7 +2903,14 @@ skopos_telecom {
       TxPower = 70  //20 kW peak, 10 kW continuous
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
+      EncoderOverride = None - Syncom Voice
       TARGET {}
+	  //If you put off this contract until 1964 tech, you can afford better than Syncom
+	  UPGRADE
+      {
+        TechLevel = 4
+        EncoderOverride = None - Early Comsat
+      }
     }
     // 9.1 meter antenna, assuming same as Apollo tracking ships when operating in C-Band [4, p.10-44]
     Antenna {
@@ -2791,7 +2921,14 @@ skopos_telecom {
       TxPower = 70
       AMWTemp = 135
       ModulationBits = 1  //FM, FSK or PSK only?
+      EncoderOverride = None - Syncom Voice
       TARGET {}
+	  //If you put off this contract until 1964 tech, you can afford better than Syncom
+	  UPGRADE
+      {
+        TechLevel = 4
+        EncoderOverride = None - Early Comsat
+      }
     }
     // Assuming same as Apollo tracking ships
     Antenna {
@@ -2836,7 +2973,14 @@ skopos_telecom {
       TxPower = 57      //500 W?
       AMWTemp = 205
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Syncom Voice
       TARGET {}
+	  //If you put off this contract until 1964 tech, you can afford better than Syncom
+	  UPGRADE
+      {
+        TechLevel = 4
+        EncoderOverride = None - Early Comsat
+      }
     }
     // Various helical/biconical antennas.
     // Assuming same as Apollo tracking ships
@@ -2880,6 +3024,7 @@ skopos_telecom {
       TxPower = 70
       AMWTemp = 135
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
     }
     // Apollo tracking ships also have VHF/UHF voice/command antenna, USB 9-meter antenna, TLM (4-1) 9-meter antenna, TLM (4-2) antenna [9, p.1-7]
@@ -2939,6 +3084,7 @@ skopos_telecom {
       TxPower = 70
       AMWTemp = 135
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
     }
     // Apollo tracking ships also have VHF/UHF voice/command antenna, USB 9-meter antenna, TLM (4-1) 9-meter antenna, TLM (4-2) antenna [9, p.1-7]
@@ -2998,6 +3144,7 @@ skopos_telecom {
       TxPower = 70
       AMWTemp = 135
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
     }
     // Apollo tracking ships also have VHF/UHF voice/command antenna, USB 9-meter antenna, TLM (4-1) 9-meter antenna, TLM (4-2) antenna [9, p.1-7]
@@ -3058,6 +3205,7 @@ skopos_telecom {
       TxPower = 65  // Same as C-Band?
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
     }
     Antenna {
@@ -3069,6 +3217,7 @@ skopos_telecom {
       TxPower = 65
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
     }
     //UHF/VHF setup same as Apollo tracking ships I guess
@@ -3124,6 +3273,7 @@ skopos_telecom {
       TxPower = 65  // Same as C-Band?
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
     }
     Antenna {
@@ -3135,6 +3285,7 @@ skopos_telecom {
       TxPower = 65
       AMWTemp = 200
       ModulationBits = 1  //FM, FSK or PSK only?
+	  EncoderOverride = None - Early Comsat
       TARGET {}
     }
     //UHF/VHF setup same as Apollo tracking ships I guess
@@ -3189,6 +3340,7 @@ skopos_telecom {
       TxPower = 43.5  // 13.5 dbW
       AMWTemp = 562
       ModulationBits = 1  //FM or PSK only
+	  EncoderOverride = None - Early Comsat  //FM voice or PSK CCITT-2 tty [12, p.257]. Data mode might have encoding but [12] doesn't say anything about it.
       TARGET {}
     }
   }
@@ -3210,6 +3362,7 @@ skopos_telecom {
       TxPower = 43.5  // 13.5 dbW
       AMWTemp = 562
       ModulationBits = 1  //FM or PSK only
+	  EncoderOverride = None - Early Comsat  //FM voice or PSK CCITT-2 tty [12, p.257]. Data mode might have encoding but [12] doesn't say anything about it.
       TARGET {}
     }
   }
@@ -3231,6 +3384,7 @@ skopos_telecom {
       TxPower = 43.5  // 13.5 dbW
       AMWTemp = 562
       ModulationBits = 1  //FM or PSK only
+	  EncoderOverride = None - Early Comsat  //FM voice or PSK CCITT-2 tty [12, p.257]. Data mode might have encoding but [12] doesn't say anything about it.
       TARGET {}
     }
   }
@@ -3252,6 +3406,7 @@ skopos_telecom {
       TxPower = 43.5  // 13.5 dbW
       AMWTemp = 562
       ModulationBits = 1  //FM or PSK only
+	  EncoderOverride = None - Early Comsat  //FM voice or PSK CCITT-2 tty [12, p.257]. Data mode might have encoding but [12] doesn't say anything about it.
       TARGET {}
     }
   }
@@ -3274,6 +3429,7 @@ skopos_telecom {
       TxPower = 43.5  // 13.5 dbW
       AMWTemp = 562
       ModulationBits = 1  //FM or PSK only
+	  EncoderOverride = None - Early Comsat  //FM voice or PSK CCITT-2 tty [12, p.257]. Data mode might have encoding but [12] doesn't say anything about it.
       TARGET {}
     }
   }
@@ -3295,6 +3451,7 @@ skopos_telecom {
       TxPower = 43.5  // 13.5 dbW
       AMWTemp = 562
       ModulationBits = 1  //FM or PSK only
+	  EncoderOverride = None - Early Comsat  //FM voice or PSK CCITT-2 tty [12, p.257]. Data mode might have encoding but [12] doesn't say anything about it.
       TARGET {}
     }
   }
@@ -3317,6 +3474,7 @@ skopos_telecom {
       TxPower = 43.5  // 13.5 dbW
       AMWTemp = 562
       ModulationBits = 1  //FM or PSK only
+	  EncoderOverride = None - Early Comsat  //FM voice or PSK CCITT-2 tty [12, p.257]. Data mode might have encoding but [12] doesn't say anything about it.
       TARGET {}
     }
   }
@@ -3338,6 +3496,7 @@ skopos_telecom {
       TxPower = 43.5  // 13.5 dbW
       AMWTemp = 562
       ModulationBits = 1  //FM or PSK only
+	  EncoderOverride = None - Early Comsat  //FM voice or PSK CCITT-2 tty [12, p.257]. Data mode might have encoding but [12] doesn't say anything about it.
       TARGET {}
     }
   }
@@ -3359,6 +3518,7 @@ skopos_telecom {
       TxPower = 43.5  // 13.5 dbW
       AMWTemp = 562
       ModulationBits = 1  //FM or PSK only
+	  EncoderOverride = None - Early Comsat  //FM voice or PSK CCITT-2 tty [12, p.257]. Data mode might have encoding but [12] doesn't say anything about it.
       TARGET {}
     }
   }
@@ -3380,6 +3540,7 @@ skopos_telecom {
       TxPower = 43.5  // 13.5 dbW
       AMWTemp = 562
       ModulationBits = 1  //FM or PSK only
+	  EncoderOverride = None - Early Comsat  //FM voice or PSK CCITT-2 tty [12, p.257]. Data mode might have encoding but [12] doesn't say anything about it.
       TARGET {}
     }
   }
@@ -3401,6 +3562,7 @@ skopos_telecom {
       TxPower = 43.5  // 13.5 dbW
       AMWTemp = 562
       ModulationBits = 1  //FM or PSK only
+	  EncoderOverride = None - Early Comsat  //FM voice or PSK CCITT-2 tty [12, p.257]. Data mode might have encoding but [12] doesn't say anything about it.
       TARGET {}
     }
   }
@@ -3422,6 +3584,7 @@ skopos_telecom {
       TxPower = 43.5  // 13.5 dbW
       AMWTemp = 562
       ModulationBits = 1  //FM or PSK only
+	  EncoderOverride = None - Early Comsat  //FM voice or PSK CCITT-2 tty [12, p.257]. Data mode might have encoding but [12] doesn't say anything about it.
       TARGET {}
     }
   }
@@ -3443,6 +3606,7 @@ skopos_telecom {
       TxPower = 43.5  // 13.5 dbW
       AMWTemp = 562
       ModulationBits = 1  //FM or PSK only
+	  EncoderOverride = None - Early Comsat  //FM voice or PSK CCITT-2 tty [12, p.257]. Data mode might have encoding but [12] doesn't say anything about it.
       TARGET {}
     }
   }
@@ -3464,6 +3628,7 @@ skopos_telecom {
       TxPower = 43.5  // 13.5 dbW
       AMWTemp = 562
       ModulationBits = 1  //FM or PSK only
+	  EncoderOverride = None - Early Comsat  //FM voice or PSK CCITT-2 tty [12, p.257]. Data mode might have encoding but [12] doesn't say anything about it.
       TARGET {}
     }
   }
@@ -3567,9 +3732,8 @@ skopos_telecom {
     name = l0p5_andover_europe
     tx = andover
     rx = pleumeur_bodou
-    rx = goonhilly_downs
     latency = 30
-    rate = 1.5e6    //4.5 MHz bandwidth, but connection is pretty marginal and we have encoders consuming bandwidth. Use 1.5 MHz [4, p.8-8]
+    rate = 1.5e6    //4.5 MHz bandwidth, but connection is pretty marginal and we are using a wider channel and possibly a higher Eb/N0. Use 1.5 MHz [4, p.8-8]
     window = 90
     exclusive = false
   }
@@ -3578,7 +3742,7 @@ skopos_telecom {
     tx = pleumeur_bodou
     rx = andover
     latency = 30
-    rate = 1.5e6    //4.5 MHz bandwidth, but connection is pretty marginal and we have encoders consuming bandwidth. Use 1.5 MHz [4, p.8-8]
+    rate = 1.5e6    //4.5 MHz bandwidth, but connection is pretty marginal and we are using a wider channel and possibly a higher Eb/N0. Use 1.5 MHz [4, p.8-8]
     window = 90
     exclusive = false
   }
@@ -3587,7 +3751,7 @@ skopos_telecom {
     tx = goonhilly_downs
     rx = andover
     latency = 30
-    rate = 1.5e6    //4.5 MHz bandwidth, but connection is pretty marginal and we have encoders consuming bandwidth. Use 1.5 MHz [4, p.8-8]
+    rate = 1.5e6    //4.5 MHz bandwidth, but connection is pretty marginal and we are using a wider channel and possibly a higher Eb/N0. Use 1.5 MHz [4, p.8-8]
     window = 90
     exclusive = false
   }
@@ -3598,7 +3762,7 @@ skopos_telecom {
     tx = kashima
     rx = point_mugu
     latency = 30
-    rate = 1.5e6    //4.5 MHz bandwidth, but connection is pretty marginal and we have encoders consuming bandwidth. Use 1.5 MHz [4, p.8-8]
+    rate = 2.5e6    //4.5 MHz bandwidth, but connection is pretty marginal and we are using a wider channel and possibly a higher Eb/N0. Kashima-Point Mugu TV consumed ~2.5 MHz [4, p.8-13]
     window = 90
     exclusive = false
   }
@@ -3607,7 +3771,7 @@ skopos_telecom {
     tx = point_mugu
     rx = kashima
     latency = 30
-    rate = 1.5e6    //4.5 MHz bandwidth, but connection is pretty marginal and we have encoders consuming bandwidth. Use 1.5 MHz [4, p.8-8]
+    rate = 2.5e6    //4.5 MHz bandwidth, but connection is pretty marginal and we are using a wider channel and possibly a higher Eb/N0. Kashima-Point Mugu TV consumed ~2.5 MHz [4, p.8-13]
     window = 90
     exclusive = false
   }


### PR DESCRIPTION
Needs https://github.com/KSP-RO/RealAntennas/pull/45

Create new encoders (or lack thereof) for skopos comsats use.
Syncom voice is based on the Syncom FMFB tuner on USNS Kingsport. With a Eb/N0 of merely 6 db, it gives Kingsport enough link margin to work with historically accurate Syncom. 6 db S/N is still about enough for a simple voice link, which is all the Kingsport terminal could do anyway.

Early Comsat is based on the standard 10 db Eb/N0 figure used as the lower limit for many early satellites. This may need to be tweaked for balance.

70s Comsat is based on the Intelsat IV SPADE bit error rate specification. Assuming an AWGN channel, an Eb/N0 of 11.4 db should provide the specified bit error rate of 1e-7.

Since the rate 1/2 encoders provided by RA are no longer consuming bandwidth, I was also able to reduce the channel size or C-band and Ku-band to their ITU standard allocations of 1 GHz (500 MHz up, 500 MHz down). This reduces channel noise a little too, helping offset the loss of encoders.

Finally, I updated ground station performance for Point Mugu and Kashima to match their configuration during the Syncom tests as closely as possible.

Telstar and Relay are mostly unaffected by these changes, and can still meet their historical performance.

Syncom, between the updates to Point Mugu/Kashima and the encoder changes, now very closely matches it's historical performance in historical configuration.

Intelsat I/II might be underperforming a little. I'm unsure if this is because they never utilized their full transponder bandwidth in normal operation, or if my Eb/N0 limits are too strict.

Intelsat III/IV perform much closer to their historical specifications without being limited by encoders.