### PR TITLE
Final balance pass before release

### DIFF
--- a/GameData/Skopos/Contracts/Level2Comsats/l2_indian_ocean_tv.cfg
+++ b/GameData/Skopos/Contracts/Level2Comsats/l2_indian_ocean_tv.cfg
@@ -73,6 +73,11 @@ CONTRACT_TYPE {
     connection = l2_indian_ocean_sir_fuc
     availability = 0.95
   }
+  PARAMETER {
+    type = AchieveConnectionAvailability
+    connection = l2_indian_ocean_log_rai
+    availability = 0.95
+  }
 
   BEHAVIOUR {
     type = AddToGroundSegment
@@ -85,10 +90,13 @@ CONTRACT_TYPE {
     station = ras_abu_jarjur
     station = fucino
     station = si_racha
+    station = logonot
+    station = raisting
     connection = l2_indian_ocean_car_goo
     connection = l2_indian_ocean_deh_goo
     connection = l2_indian_ocean_ras_fuc
     connection = l2_indian_ocean_sir_fuc
+    connection = l2_indian_ocean_log_rai
   }
 }
 

--- a/GameData/Skopos/Contracts/Level2Comsats/l2_north_atlantic_tv.cfg
+++ b/GameData/Skopos/Contracts/Level2Comsats/l2_north_atlantic_tv.cfg
@@ -73,6 +73,11 @@ CONTRACT_TYPE {
     connection = l2_atlantic_cho_bui
     availability = 0.95
   }
+  PARAMETER {
+    type = AchieveConnectionAvailability
+    connection = l2_atlantic_tan_bui
+    availability = 0.95
+  }
 
   BEHAVIOUR {
     type = AddToGroundSegment
@@ -86,10 +91,12 @@ CONTRACT_TYPE {
     station = pleumeur_bodou
     station = choconta
     station = buitrago
+    station = tangua
     connection = l2_atlantic_and_goo
     connection = l2_atlantic_ros_rai
     connection = l2_atlantic_and_ple
     connection = l2_atlantic_cho_bui
+    connection = l2_atlantic_tan_bui
   }
 }
 

--- a/GameData/Skopos/Contracts/Level2Comsats/l2_pacific_tv.cfg
+++ b/GameData/Skopos/Contracts/Level2Comsats/l2_pacific_tv.cfg
@@ -73,6 +73,11 @@ CONTRACT_TYPE {
     connection = l2_pacific_bre_coo
     availability = 0.95
   }
+  PARAMETER {
+    type = AchieveConnectionAvailability
+    connection = l2_pacific_hon_car
+    availability = 0.95
+  }
 
   BEHAVIOUR {
     type = AddToGroundSegment
@@ -85,10 +90,13 @@ CONTRACT_TYPE {
     station = kashima
     station = yangmingshang
     station = cooby_creek
+    station = hong_kong
+    station = otc_carnarvon
     connection = l2_pacific_bre_pau
     connection = l2_pacific_poi_kas
     connection = l2_pacific_poi_yan
     connection = l2_pacific_bre_coo
+    connection = l2_pacific_hon_car
   }
 }
 

--- a/GameData/Skopos/Contracts/Level3Comsats/l3_canunet_rtv.cfg
+++ b/GameData/Skopos/Contracts/Level3Comsats/l3_canunet_rtv.cfg
@@ -1,0 +1,76 @@
+// Sort keys:
+// SRA
+// |||
+// ||Action: 0 set up, 1 maintain, 2 events.
+// |Region: 1 Atlantic, 2 Pacific, 3 Indian Ocean, 4 Soviet Union, 5 Paris-Moscow, 6 Intersputnik, 8 World
+// Service Level: 0 intermittent, 1 intermediate (~50%), 2 sustained (95%).
+CONTRACT_TYPE {
+  name = l3_canunet_rtv
+  has_maintenance = true
+  agent = skopos_telecom_agent
+  group = skopos_telecom_group
+  sortKey = 210
+  title = (PLACEHOLDER CONTRACT) Canadian Remote TV - Level 1
+  description = <b>Program: Third Generation Telecommunications Satellites (Skopos Beta)<br>Type: <color=blue>Optional</color></b><br><br>The Canadian government has called for the establishment of a commercial, domestic satellite system to provide telecommunications services throughout the nearly 10 million square kilometers (4 million square miles) of Canada extending across six time zones. Hundreds of small towns, hamlets and clusters of isolated communities in northern areas have very limited communications. Satellite service offers a way for TV and radio programs to be distrubuted to remote communities in the Canadian north.
+  notes = New TV Recieve-Only (TVRO) satellite earth stations have been constructed in communities across the Canadian shield. These basic stations have no tracking capability, so you will need to aim them at a point in the sky and ensure a satellite is always within their field of view. The TV feed will be provided from Allan Park satellite earth stations. <br><color=orange>Author's note: TVRO stations currently function like any other ground station. This contract is just a placeholder until TVRO support is added.</color>
+  synopsis = Provide remote telecom for 90 days with 95% availability (~23 h per day).
+  completedMessage = The Canadian domestic telecommunications network can now provide national TV and radio service to hundreds of communities across the Canadian shield.
+
+  rewardReputation = 500
+
+  REQUIREMENT {
+    name = All
+    type = All
+    REQUIREMENT {
+      name = Any
+      type = Any
+      //If it isn't completed during this program, it will appear in the next program
+      REQUIREMENT {
+        name = ProgramActive
+        type = ProgramActive
+        program = SkoposLevel3Comsats
+      }
+    }
+    REQUIREMENT {
+      name = Any
+      type = Any
+    }
+  }
+
+  PARAMETER {
+    type = AchieveConnectionAvailability
+    connection = l3_canunet_rtv_tvro
+    availability = 0.95
+  }
+PARAMETER {
+    type = AchieveConnectionAvailability
+    connection = l3_canunet_ntc_all_fro
+    availability = 0.95
+  }
+PARAMETER {
+    type = AchieveConnectionAvailability
+    connection = l3_canunet_ntc_all_res
+    availability = 0.95
+  }
+
+  BEHAVIOUR {
+    type = AddToGroundSegment
+    condition {
+      state = CONTRACT_OFFERED
+    }
+    station = allan_park
+    station = whitehorse
+    station = frobisher_bay
+    station = port_au_port
+    station = resolute
+    connection = l3_canunet_rtv_tvro
+    connection = l3_canunet_ntc_all_fro
+    connection = l3_canunet_ntc_all_res
+  }
+}
+
+@CONTRACT_TYPE[maintenance_l3_canunet_rtv] {
+  %description = Ensure that our telecommunications infrastructure remains in working order.
+  %synopsis = Provide Level 3 service to Canada with 95% availability.
+  %completedMessage = We have completed another month of successful operation of the level 3 Canadian remote telecommunications relay.
+}

--- a/GameData/Skopos/Contracts/Level3Comsats/l3_ekran.cfg
+++ b/GameData/Skopos/Contracts/Level3Comsats/l3_ekran.cfg
@@ -1,0 +1,65 @@
+// Sort keys:
+// SRA
+// |||
+// ||Action: 0 set up, 1 maintain, 2 events.
+// |Region: 1 Atlantic, 2 Pacific, 3 Indian Ocean, 4 Soviet Union, 5 Paris-Moscow, 6 Intersputnik, 8 World
+// Service Level: 0 intermittent, 1 intermediate (~50%), 2 sustained (95%).
+CONTRACT_TYPE {
+  name = l3_ekran
+  has_maintenance = true
+  agent = skopos_telecom_agent
+  group = skopos_telecom_group
+  sortKey = 210
+  title = (PLACEHOLDER CONTRACT) Soviet Direct-to-Home Television - Level 1
+  description = <b>Program: Third Generation Telecommunications Satellites (Skopos Beta)<br>Type: <color=blue>Optional</color></b><br><br>Although satellite communications have brought state TV to millions across the vast territories of the Soviet Union, large swathes of territory remain without coverage. Even with recent advances in telecommunications technology, the satellite earth stations required to track, recieve and demodulate signals from out existing satellite network are too expensive and complex to install in every village, hamlet and logging camp across the vast territories of Siberia. Instead, we would like to transmit TV signals directly from orbit, where they can be recieved with standard TV and radio equipment, bringing accessible television to the entire Union.
+  notes = Rollout of new TV tuners and antennas has begun across the Soviet Union. These basic, TV Recieve-Only (TVRO) systems have no tracking capability so you will need to aim them at a point in the sky and ensure a satellite is always within their field of view. <br><color=orange>Author's note: TVRO stations currently function like any other ground station. This contract is just a placeholder until TVRO support is added.</color>
+  synopsis = Provide remote telecom for 90 days with 95% availability (~23 h per day).
+  completedMessage = The Soviet direct-to-home network can now provide state TV and radio service to anyone with a television or radio in the Soviet Union.
+
+  rewardReputation = 500
+
+  REQUIREMENT {
+    name = All
+    type = All
+    REQUIREMENT {
+      name = Any
+      type = Any
+      //If it isn't completed during this program, it will appear in the next program
+      REQUIREMENT {
+        name = ProgramActive
+        type = ProgramActive
+        program = SkoposLevel3Comsats
+      }
+    }
+    REQUIREMENT {
+      name = Any
+      type = Any
+    }
+  }
+
+  PARAMETER {
+    type = AchieveConnectionAvailability
+    connection = l3_ekran_tv
+    availability = 0.95
+  }
+
+  BEHAVIOUR {
+    type = AddToGroundSegment
+    condition {
+      state = CONTRACT_OFFERED
+    }
+    station = moscow
+    station = novy_urengoy
+    station = udachnyi
+    station = ugolnoye
+    station = baruun_urt
+    station = murghab
+    connection = l3_ekran_tv
+  }
+}
+
+@CONTRACT_TYPE[maintenance_l3_ekran] {
+  %description = Ensure that our telecommunications infrastructure remains in working order.
+  %synopsis = Provide Level 3 service to Canada with 95% availability.
+  %completedMessage = We have completed another month of successful operation of the level 3 Canadian remote telecommunications relay.
+}

--- a/GameData/Skopos/Contracts/Level3Comsats/l3_hbo_us.cfg
+++ b/GameData/Skopos/Contracts/Level3Comsats/l3_hbo_us.cfg
@@ -1,0 +1,66 @@
+// Sort keys:
+// SRA
+// |||
+// ||Action: 0 set up, 1 maintain, 2 events.
+// |Region: 1 Atlantic, 2 Pacific, 3 Indian Ocean, 4 Soviet Union, 5 Paris-Moscow, 6 Intersputnik, 8 World
+// Service Level: 0 intermittent, 1 intermediate (~50%), 2 sustained (95%).
+// Placeholder contract until TVRO features are added
+CONTRACT_TYPE {
+  name = l3_hbo_us
+  has_maintenance = true
+  agent = skopos_telecom_agent
+  group = skopos_telecom_group
+  sortKey = 210
+  title = (PLACEHOLDER CONTRACT) US Domestic TV Recieve-Only Service - Level 1
+  description = <b>Program: Third Generation Telecommunications Satellites (Skopos Beta)<br>Type: <color=blue>Optional</color></b><br><br>Many TV studios have expressed interest in using leased domestic satellite communications to distribute TV programs. This will allow TV programs to be produced at a single central studio and be instantly transmitted to dozens of local studios across the country. In order to reduce costs, however, local TV studios will be equipped with very basic 4.5-meter satellite earth stations.
+  notes = New TV Recieve-Only (TVRO) satellite earth stations have been constructed at TV studios across the country. These basic stations have no tracking capability, so you will need to aim them at a point in the sky and ensure a satellite is always within their field of view. The TV feed will be provided from leased antennas at the Vernon Valley and Moorepark satellite earth stations. <br><color=orange>Author's note: TVRO stations currently function like any other ground station. This contract is just a placeholder until TVRO support is added.</color>
+  synopsis = Provide domestic TV Recieve-Only (TVRO) service for 90 days with 95% availability (~23 h per day).
+  completedMessage = TVRO service has proved a massive hit among TV studios, allowing live coverage of news and sports events across the country, and the creation of premium pay television featuring special TV programs created in centralized TV studios and distributed by satellite.
+
+  rewardReputation = 500
+
+  REQUIREMENT {
+    name = All
+    type = All
+    REQUIREMENT {
+      name = Any
+      type = Any
+      //If it isn't completed during this program, it will appear in the next program
+      REQUIREMENT {
+        name = ProgramActive
+        type = ProgramActive
+        program = SkoposLevel3Comsats
+      }
+    }
+  }
+
+  PARAMETER {
+    type = AchieveConnectionAvailability
+    connection = l3_hbo_us_est
+    availability = 0.95
+  }
+PARAMETER {
+    type = AchieveConnectionAvailability
+    connection = l3_hbo_us_pst
+    availability = 0.95
+  }
+
+  BEHAVIOUR {
+    type = AddToGroundSegment
+    condition {
+      state = CONTRACT_OFFERED
+    }
+    station = vernon_valley
+    station = moorepark
+    station = chicago
+    station = denver
+    connection = l3_hbo_us_est
+    connection = l3_hbo_us_pst
+  }
+}
+
+@CONTRACT_TYPE[maintenance_l3_hbo_us] {
+  %description = Ensure that our telecommunications infrastructure remains in working order.
+  %synopsis = Provide Level 1 TVRO service to the continental United States with 95% availability.
+  %completedMessage = We have completed another month of successful operation of the Level 1 TVRO service.
+}

--- a/GameData/Skopos/Contracts/Level3Comsats/l3_indian_ocean_tv.cfg
+++ b/GameData/Skopos/Contracts/Level3Comsats/l3_indian_ocean_tv.cfg
@@ -68,6 +68,11 @@ CONTRACT_TYPE {
     connection = l3_indian_ocean_sir_fuc
     availability = 0.95
   }
+  PARAMETER {
+    type = AchieveConnectionAvailability
+    connection = l3_indian_ocean_log_rai
+    availability = 0.95
+  }
 
   BEHAVIOUR {
     type = AddToGroundSegment
@@ -80,10 +85,12 @@ CONTRACT_TYPE {
     station = ras_abu_jarjur
     station = fucino
     station = si_racha
+    station = logonot
     connection = l3_indian_ocean_car_goo
     connection = l3_indian_ocean_deh_goo
     connection = l3_indian_ocean_ras_fuc
     connection = l3_indian_ocean_sir_fuc
+    connection = l3_indian_ocean_log_rai
   }
 }
 

--- a/GameData/Skopos/Contracts/Level3Comsats/l3_north_atlantic_tv.cfg
+++ b/GameData/Skopos/Contracts/Level3Comsats/l3_north_atlantic_tv.cfg
@@ -68,6 +68,11 @@ CONTRACT_TYPE {
     connection = l3_atlantic_cho_bui
     availability = 0.95
   }
+  PARAMETER {
+    type = AchieveConnectionAvailability
+    connection = l3_atlantic_tan_bui
+    availability = 0.95
+  }
 
   BEHAVIOUR {
     type = AddToGroundSegment
@@ -81,10 +86,12 @@ CONTRACT_TYPE {
     station = raisting
     station = choconta
     station = buitrago
+    station = tangua
     connection = l3_atlantic_and_ple
     connection = l3_atlantic_and_goo
     connection = l3_atlantic_ros_rai
     connection = l3_atlantic_cho_bui
+    connection = l3_atlantic_tan_bui
   }
 }
 

--- a/GameData/Skopos/Contracts/Level3Comsats/l3_pacific_tv.cfg
+++ b/GameData/Skopos/Contracts/Level3Comsats/l3_pacific_tv.cfg
@@ -68,6 +68,11 @@ CONTRACT_TYPE {
     connection = l3_pacific_bre_coo
     availability = 0.95
   }
+  PARAMETER {
+    type = AchieveConnectionAvailability
+    connection = l3_pacific_hon_car
+    availability = 0.95
+  }
 
   BEHAVIOUR {
     type = AddToGroundSegment
@@ -80,10 +85,12 @@ CONTRACT_TYPE {
     station = paumalu
     station = yangmingshang
     station = cooby_creek
+    station = hong_kong
     connection = l3_pacific_poi_kas
     connection = l3_pacific_bre_pau
     connection = l3_pacific_poi_yan
     connection = l3_pacific_bre_coo
+    connection = l3_pacific_hon_car
   }
 }
 

--- a/GameData/Skopos/Programs/Programs.cfg
+++ b/GameData/Skopos/Programs/Programs.cfg
@@ -236,8 +236,8 @@ RP0_PROGRAM
 		l3_canunet = true
 		l3_us_territories = true
 		l3_canunet_rtv = true
-		//l3_ekran = true
-		//l3_hbo = true
+		l3_ekran = true
+		l3_hbo = true
 		//l3_ats6_appalachia = true
 		//l3_ats6_india = true
 		//l3_ats6_china = true

--- a/GameData/Skopos/telecom.cfg
+++ b/GameData/Skopos/telecom.cfg
@@ -780,6 +780,101 @@ skopos_telecom {
       TxPower = 43      //20 W
       AMWTemp = 670
       ModulationBits = 1  //FM, FSK or PSK only?
+      EncoderOverride = None - 70s Comsat
+      TARGET {}
+    }
+  }
+  station {
+    name = whitehorse
+    objectName = Whitehorse
+    lat = 60.719708
+    lon = -135.054984
+    // 675 m ASL, and the centre of the antennna is about 10 m above the
+    // ground.
+    alt = 685
+    role = rx
+    //Ground station performance data [4, p.18-24]
+    //Remote TV station, one channel recieve only
+    Antenna {
+      TechLevel = 3
+      RFBand = C (Wideband)
+      referenceGain = 48.5
+      referenceFrequency = 4768
+      // Rx only, just make sure RA connects.
+      TxPower = 120.828  // 1.21 GW!
+      AMWTemp = 150
+      ModulationBits = 1  //FM, FSK or PSK only?
+      EncoderOverride = None - 70s Comsat
+      TARGET {}
+    }
+  }
+  station {
+    name = port_au_port
+    objectName = Port au Port
+    lat = 48.588888
+    lon = -58.664289
+    // 365 m ASL, and the centre of the antennna is about 10 m above the
+    // ground.
+    alt = 375
+    role = rx
+    //Ground station performance data [4, p.18-24]
+    //Remote TV station, one channel recieve only
+    Antenna {
+      TechLevel = 3
+      RFBand = C (Wideband)
+      referenceGain = 48.5
+      referenceFrequency = 4768
+      // Rx only, just make sure RA connects.
+      TxPower = 120.828  // 1.21 GW!
+      AMWTemp = 150
+      ModulationBits = 1  //FM, FSK or PSK only?
+      EncoderOverride = None - 70s Comsat
+      TARGET {}
+    }
+  }
+  station {
+    name = frobisher_bay
+    objectName = Frobisher Bay
+    lat = 63.780803
+    lon = -68.545119
+    // 155 m ASL, and the centre of the antennna is about 10 m above the
+    // ground.
+    alt = 165
+    role = trx
+    //Ground station performance data [4, p.18-24]
+    //Northern telecom station, capable of TV recieve or voice circuits
+    Antenna {
+      TechLevel = 3
+      RFBand = C (Wideband)
+      referenceGain = 50.6
+      referenceFrequency = 4768
+      TxPower = 61.8  // 1.5 kW
+      AMWTemp = 150
+      ModulationBits = 1  //FM, FSK or PSK only?
+      EncoderOverride = None - 70s Comsat
+      TARGET {}
+    }
+  }
+  station {
+    name = resolute
+    objectName = Resolute
+    lat = 74.696977
+    lon = -94.833109
+    // 15 m ASL, and the centre of the antennna is about 10 m above the
+    // ground.
+    alt = 25
+    role = trx
+    //Ground station performance data [4, p.18-24]
+    //Northern telecom station, message service only
+    Antenna {
+      TechLevel = 3
+      RFBand = C (Wideband)
+      referenceGain = 50.6
+      referenceFrequency = 4768
+      TxPower = 61.8  // 1.5 kW
+      AMWTemp = 150
+      ModulationBits = 1  //FM, FSK or PSK only?
+      EncoderOverride = None - 70s Comsat
       TARGET {}
     }
   }
@@ -800,10 +895,36 @@ skopos_telecom {
       RFBand = C (Wideband)
       referenceGain = 42.7
       referenceFrequency = 4768
+      // Rx only, just make sure RA connects.
+      TxPower = 120.828  // 1.21 GW!
+      AMWTemp = 205
+      ModulationBits = 2  //ASC recieve-only terminals could operate in QPSK
+      EncoderOverride = None - 70s Comsat
+      TARGET {}
+    }
+  }
+    station {
+    name = denver
+    objectName = Denver
+    lat = 39.739354
+    lon = -104.988971
+    // 1600 m ASL, and the centre of the antennna is about 10 m above the
+    // ground.
+    alt = 1610
+    role = rx
+    //Ground station performance data [6, p.81]
+    //This is just a placeholder station, representing generic commercial recieving stations
+    //Based WB 39 4.5m Antenna
+    Antenna {
+      TechLevel = 3
+      RFBand = C (Wideband)
+      referenceGain = 42.7
+      referenceFrequency = 4768
      // Rx only, just make sure RA connects.
       TxPower = 120.828  // 1.21 GW!
       AMWTemp = 205
       ModulationBits = 2  //ASC recieve-only terminals could operate in QPSK
+      EncoderOverride = None - 70s Comsat
       TARGET {}
     }
   }
@@ -3868,7 +3989,7 @@ skopos_telecom {
 //  ==================================================
 //  level 2 connections
 //  North Atlantic
-//  168 MHz, equivalent to ~1.5 Intelsat-III
+//  216 MHz, equivalent to ~0.5 Intelsat-III
   connection {
     name = l2_atlantic_and_goo
     trx = andover
@@ -3905,8 +4026,17 @@ skopos_telecom {
     window = 90
     exclusive = true
   }
+  connection {
+    name = l2_atlantic_tan_bui
+    trx = tangua
+    trx = buitrago
+    latency = 0.80
+    rate = 24e6
+    window = 90
+    exclusive = true
+  }
 //  Pacific
-//  168 MHz, equivalent to ~1.5 Intelsat-III
+//  216 MHz, equivalent to ~0.5 Intelsat-III
   connection {
     name = l2_pacific_bre_pau
     trx = brewster_flats
@@ -3943,8 +4073,17 @@ skopos_telecom {
     window = 90
     exclusive = true
   }
+  connection {
+    name = l2_pacific_hon_car
+    trx = hong_kong
+    trx = otc_carnarvon
+    latency = 0.80
+    rate = 24e6
+    window = 90
+    exclusive = true
+  }
 //  Indian Ocean
-//  168 MHz, equivalent to ~1.5 Intelsat-III
+//  216 MHz, equivalent to ~0.5 Intelsat-III
   connection {
     name = l2_indian_ocean_car_goo
     trx = otc_carnarvon
@@ -3976,6 +4115,15 @@ skopos_telecom {
     name = l2_indian_ocean_sir_fuc
     trx = si_racha
     trx = fucino
+    latency = 0.80
+    rate = 24e6
+    window = 90
+    exclusive = true
+  }
+  connection {
+    name = l2_indian_ocean_log_rai
+    trx = logonot
+    trx = raisting
     latency = 0.80
     rate = 24e6
     window = 90
@@ -4160,7 +4308,7 @@ skopos_telecom {
 //  level 3 connections
 
 //  Atlantic
-//  768 MHz
+//  960 MHz
   connection {
     name = l3_atlantic_and_ple
     trx = andover
@@ -4197,9 +4345,18 @@ skopos_telecom {
     window = 90
     exclusive = true
   }
+  connection {
+    name = l3_atlantic_tan_bui
+    trx = tangua
+    trx = buitrago
+    latency = 0.80
+    rate = 96e6
+    window = 90
+    exclusive = true
+  }
 
 //  Pacific
-//  10x4 channels
+//  960 MHz
   connection {
     name = l3_pacific_poi_kas
     trx = point_mugu
@@ -4236,9 +4393,18 @@ skopos_telecom {
     window = 90
     exclusive = true
   }
+  connection {
+    name = l3_pacific_hon_car
+    trx = hong_kong
+    trx = otc_carnarvon
+    latency = 0.80
+    rate = 96e6
+    window = 90
+    exclusive = true
+  }
 
 //  Indian Ocean
-//  10x4 channels
+//  960 MHz
   connection {
     name = l3_indian_ocean_car_goo
     trx = otc_carnarvon
@@ -4270,6 +4436,15 @@ skopos_telecom {
     name = l3_indian_ocean_sir_fuc
     trx = si_racha
     trx = fucino
+    latency = 0.80
+    rate = 96e6
+    window = 90
+    exclusive = true
+  }
+  connection {
+    name = l3_indian_ocean_log_rai
+    trx = logonot
+    trx = raisting
     latency = 0.80
     rate = 96e6
     window = 90
@@ -4361,6 +4536,27 @@ skopos_telecom {
     exclusive = true
   }
 
+//  TVRO placeholder
+//  4 original users (ABC, NBC, CBS, HBO) with 1 36 MHz transponder each. 144 MHz each for east and west
+  connection {
+    name = l3_hbo_us_est
+    tx = vernon_valley
+    rx = chicago
+    latency = 0.80
+    rate = 144e6
+    window = 90
+    exclusive = true
+  }
+  connection {
+    name = l3_hbo_us_pst
+    tx = moorepark
+    rx = denver
+    latency = 0.80
+    rate = 144e6
+    window = 90
+    exclusive = true
+  }
+
 //  Canadian domestic communications (Canunet)
   connection {
     name = l3_canunet_har_all
@@ -4399,29 +4595,63 @@ skopos_telecom {
     exclusive = true
   }
 
+//  Canadian remote communications (Canunet RTV and NTC)
+//  one channel (36 MHz) dedicated to RTV? One channel dedicated to NTC service
+  connection {
+    name = l3_canunet_rtv_tvro
+    tx = allan_park
+    rx = whitehorse
+    rx = frobisher_bay
+    rx = port_au_port
+    latency = 0.80
+    rate = 36e6
+    window = 90
+    exclusive = true
+  }
+//  Frobisher Bay can handle voice circuits. Give half of NTC voice allocation (132 5 kHz cicuits?) for 5x66 = 330 kHz
+  connection {
+    name = l3_canunet_ntc_all_fro
+    trx = allan_park
+    trx = frobisher_bay
+    latency = 0.80
+    rate = 330e3
+    window = 90
+    exclusive = true
+  }
+//  Resolute limited to message service only (2400 bps?)
+  connection {
+    name = l3_canunet_ntc_all_res
+    trx = allan_park
+    trx = resolute
+    latency = 0.80
+    rate = 2400
+    window = 90
+    exclusive = true
+  }
+
 //  CTS (Hermes) Ku-band test
   connection {
     name = l3_hermes_remote
     trx = allan_park
     trx = yellowknife
     latency = 0.80
-    rate = 12e6
+    rate = 36e6
     window = 90
     exclusive = true
   }
 
 //  Marisat
+//  Marisat rated for 9 voice circuits or 110 tty circuits
+//  tty consumes 1,100 bps data rate (both ways)
+//  voice consumes 27 kHz (both ways), ~27 kbps
+//  capable of supporting 9 simultaneous voice links per satellite. We only 4 ships per region though
+//  9/4 * 27 = 60.75 kbps
   connection {
     name = l3_marisat_natlantic
     trx = southbury
     trx = ship_north_atlantic
     latency = 0.80
-    //Marisat rated for 9 voice circuits or 110 tty circuits
-    //tty consumes 1,100 bps data rate (both ways)
-    //voice consumes 27 kHz (both ways), ~27 kbps
-    //the limiting factor here is actually the shipboard terminal, it can only support 1 voice circuit
-    //Ask for 30 kbps I guess
-    rate = 30e3
+    rate = 60.75e3
     window = 90
     exclusive = true
   }
@@ -4430,7 +4660,7 @@ skopos_telecom {
     trx = southbury
     trx = ship_south_atlantic
     latency = 0.80
-    rate = 30e3
+    rate = 60.75e3
     window = 90
     exclusive = true
   }
@@ -4439,7 +4669,7 @@ skopos_telecom {
     trx = southbury
     trx = ship_caribbean
     latency = 0.80
-    rate = 30e3
+    rate = 60.75e3
     window = 90
     exclusive = true
   }
@@ -4448,7 +4678,7 @@ skopos_telecom {
     trx = southbury
     trx = ship_east_africa
     latency = 0.80
-    rate = 30e3
+    rate = 60.75e3
     window = 90
     exclusive = true
   }
@@ -4457,7 +4687,7 @@ skopos_telecom {
     trx = santa_paula
     trx = ship_bering
     latency = 0.80
-    rate = 30e3
+    rate = 60.75e3
     window = 90
     exclusive = true
   }
@@ -4466,7 +4696,7 @@ skopos_telecom {
     trx = santa_paula
     trx = ship_south_pacific
     latency = 0.80
-    rate = 30e3
+    rate = 60.75e3
     window = 90
     exclusive = true
   }
@@ -4475,7 +4705,7 @@ skopos_telecom {
     trx = santa_paula
     trx = ship_south_china
     latency = 0.80
-    rate = 30e3
+    rate = 60.75e3
     window = 90
     exclusive = true
   }
@@ -4484,7 +4714,7 @@ skopos_telecom {
     trx = santa_paula
     trx = ship_east_pacific
     latency = 0.80
-    rate = 30e3
+    rate = 60.75e3
     window = 90
     exclusive = true
   }
@@ -4743,7 +4973,7 @@ skopos_telecom {
 
 //  Ekran
   connection {
-    name = l3_ekran
+    name = l3_ekran_tv
     tx = moscow
     rx = novy_urengoy
     rx = udachnyi


### PR DESCRIPTION
Final balance and some final touches before trying to ship for release.
The most significant change is increasing L2 and L3 intelsat contracts to have 5 ground station pairs, to increase bandwidth usage to realistic levels and increase the required coverage area to match real requirements.
Also some functional placeholder contracts for TVRO stuff have been added (US domestic TVRO/HBO, Canunet RTV/NTC, and Ekran). They are unable to enforce non-tracking ground stations, but otherwise should replicate the requirements accurately.

Needs https://github.com/mockingbirdnest/Skopos/pull/21 for encoders