### PR TITLE
Fix version file URL property

### DIFF
--- a/GameData/Skopos/Skopos.version
+++ b/GameData/Skopos/Skopos.version
@@ -1,6 +1,6 @@
 {
     "NAME": "RealismOverhaul",
-    "URL": "https://raw.githubusercontent.com/mockingbirdnest/Skopos/tree/master/GameData/Skopos/Skopos.version",
+    "URL": "https://raw.githubusercontent.com/mockingbirdnest/Skopos/master/GameData/Skopos/Skopos.version",
     "DOWNLOAD": "https://github.com/mockingbirdnest/Skopos/releases",
     "GITHUB": {
         "USERNAME": "eggrobin",


### PR DESCRIPTION
Hi @eggrobin, @pleroy, and @Capkirk123,

The current URL is a 404 (pasted below for easy clicking):

- <https://raw.githubusercontent.com/mockingbirdnest/Skopos/tree/master/GameData/Skopos/Skopos.version>

Without `tree/`, it works. Cheers!

Noticed while reviewing KSP-CKAN/NetKAN#10376.
