### PR TITLE
Set "show network" to off by default

### DIFF
--- a/Telecom/main_window.cs
+++ b/Telecom/main_window.cs
@@ -10,7 +10,7 @@ internal class MainWindow : principia.ksp_plugin_adapter.SupervisedWindowRendere
     telecom_ = telecom;
   }
 
-  public bool show_network { get; private set; } = true;
+  public bool show_network { get; private set; } = false;
 
   protected override string Title => "Σκοπός Telecom network overview";
 


### PR DESCRIPTION
Set "show network" to off by default, because opening the map with "show network" enabled causes lag probably, and is also undesired in general.

resolves https://github.com/mockingbirdnest/Skopos/issues/7
also at least suppresses https://github.com/mockingbirdnest/Skopos/issues/28 and https://github.com/mockingbirdnest/Skopos/issues/9 (hopefully)