### PR TITLE
Only load Skopos in career games

### DIFF
--- a/Telecom/telecom.cs
+++ b/Telecom/telecom.cs
@@ -8,7 +8,8 @@ using System.Runtime.CompilerServices;
 
 namespace σκοπός {
   [KSPScenario(
-    ScenarioCreationOptions.AddToAllGames,
+    ScenarioCreationOptions.AddToNewCareerGames | ScenarioCreationOptions.AddToExistingCareerGames |
+    ScenarioCreationOptions.RemoveFromSandboxGames | ScenarioCreationOptions.RemoveFromScienceSandboxGames,
     new[] { GameScenes.SPACECENTER, GameScenes.TRACKSTATION, GameScenes.FLIGHT, GameScenes.EDITOR })]
   public sealed class Telecom : ScenarioModule, principia.ksp_plugin_adapter.SupervisedWindowRenderer.ISupervisor {
 


### PR DESCRIPTION
In sandbox saves, there's no instance of `ContractSystem`. This causes a NRE to be thrown from `Network.UpdateConnections()` in every FixedUpdate.

With this change, Skopos doesn't get loaded in Sandbox or Science mode save files: they don't have contracts, so Skopos wouldn't do anything anyways.

Fixes #8