### PR TITLE
Possible fix for lag on opening map view

### DIFF
--- a/Telecom/telecom.cs
+++ b/Telecom/telecom.cs
@@ -114,6 +114,9 @@ namespace σκοπός {
       if (!main_window_.show_network) {
         return;
       }
+      if (!MapView.MapIsEnabled) {
+        return;
+      }
       var ui = CommNet.CommNetUI.Instance as RACommNetUI;
       if (ui == null) {
         return;


### PR DESCRIPTION
Possible fix for #9. It's an issue I was facing and this change has worked for me with the issue not reoccurring after several hours of playing, but I say possible as I don't have any real understanding as to exactly what the underlying issue is that caused it so don't know if it's properly fixed or is just coincidence. This change was essentially just a shot in the dark with the logic of "Show network being enabled works fine in flight, and works fine in map view, it's only the transition between flight and map view that can cause issues, so add a check to make sure we're in the map view properly to hopefully prevent any weirdness that could happen during the transition.", and it seems to have worked for me so I figured I'd make a PR.