### PR TITLE
Remove toolbar button from VAB and SPH where it cannot be used

### DIFF
--- a/Telecom/telecom.cs
+++ b/Telecom/telecom.cs
@@ -57,9 +57,9 @@ namespace σκοπός {
                     ALWAYS & ~KSP.UI.Screens.ApplicationLauncher.AppScenes.VAB & ~KSP.UI.Screens.ApplicationLauncher.AppScenes.SPH,
                 texture         : toolbar_button_texture);
       }
-      //if (HighLogic.LoadedScene == GameScenes.EDITOR) {
-      //  main_window_.Hide();
-      //}
+      if (HighLogic.LoadedScene == GameScenes.EDITOR) {
+        main_window_.Hide();
+      }
       // Make sure the state of the toolbar button remains consistent with the
       // state of the window.
       if (main_window_.Shown()) {

--- a/Telecom/telecom.cs
+++ b/Telecom/telecom.cs
@@ -53,8 +53,10 @@ namespace σκοπός {
                 onHoverOut      : null,
                 onEnable        : null,
                 onDisable       : null,
-                visibleInScenes : KSP.UI.Screens.ApplicationLauncher.AppScenes.
-                    ALWAYS & ~KSP.UI.Screens.ApplicationLauncher.AppScenes.VAB & ~KSP.UI.Screens.ApplicationLauncher.AppScenes.SPH,
+                visibleInScenes :
+                    KSP.UI.Screens.ApplicationLauncher.AppScenes.ALWAYS &
+                    ~KSP.UI.Screens.ApplicationLauncher.AppScenes.VAB &
+                    ~KSP.UI.Screens.ApplicationLauncher.AppScenes.SPH,
                 texture         : toolbar_button_texture);
       }
       if (HighLogic.LoadedScene == GameScenes.EDITOR) {

--- a/Telecom/telecom.cs
+++ b/Telecom/telecom.cs
@@ -54,12 +54,12 @@ namespace σκοπός {
                 onEnable        : null,
                 onDisable       : null,
                 visibleInScenes : KSP.UI.Screens.ApplicationLauncher.AppScenes.
-                    ALWAYS,
+                    ALWAYS & ~KSP.UI.Screens.ApplicationLauncher.AppScenes.VAB & ~KSP.UI.Screens.ApplicationLauncher.AppScenes.SPH,
                 texture         : toolbar_button_texture);
       }
-      if (HighLogic.LoadedScene == GameScenes.EDITOR) {
-        main_window_.Hide();
-      }
+      //if (HighLogic.LoadedScene == GameScenes.EDITOR) {
+      //  main_window_.Hide();
+      //}
       // Make sure the state of the toolbar button remains consistent with the
       // state of the window.
       if (main_window_.Shown()) {


### PR DESCRIPTION
Fixes https://github.com/mockingbirdnest/Skopos/issues/35
Confirmation:
![image](https://github.com/user-attachments/assets/2bb26c79-b15b-482e-97cb-4cd1a5e6bce0)
![image](https://github.com/user-attachments/assets/87d5bf13-2a5d-408a-add2-f3c9c22de7ea)

![image](https://github.com/user-attachments/assets/0894d86b-92f6-4841-95f3-cde9e78bf5d1)
![image](https://github.com/user-attachments/assets/2064771c-42c9-4571-b03f-f3160d5c142c)
