### PR TITLE
Add L-band antennas to more ground stations

### DIFF
--- a/GameData/Skopos/telecom.cfg
+++ b/GameData/Skopos/telecom.cfg
@@ -187,6 +187,18 @@ skopos_telecom {
     // ground.
     alt = 895
     role = trx
+    //C-band antenna in L-band for gameplay reasons
+    Antenna {
+      TechLevel = 3
+      RFBand = L (Wideband)     //just let RA autocalculate gain
+      referenceGain = 58.4
+      referenceFrequency = 4768
+      TxPower = 63
+      AMWTemp = 214     //230K-16K. Based on Syncom AN/FSC-9 terminals [4, p.8-10]. -16K for RA atmo noise
+      ModulationBits = 1  //FM, FSK or PSK only?
+      EncoderOverride = None - Early Comsat
+      TARGET {}
+    }
     //Ground station performance data [4, p. 13-16]
     Antenna {
       TechLevel = 3
@@ -227,6 +239,18 @@ skopos_telecom {
     // ground.
     alt = 397
     role = trx
+    //C-band antenna in L-band for gameplay reasons
+    Antenna {
+      TechLevel = 3
+      RFBand = L (Wideband)     //just let RA autocalculate gain
+      referenceGain = 58.4
+      referenceFrequency = 4768
+      TxPower = 70
+      AMWTemp = 214     //230K-16K. Based on Syncom AN/FSC-9 terminals [4, p.8-10]. -16K for RA atmo noise
+      ModulationBits = 1  //FM, FSK or PSK only?
+      EncoderOverride = None - Early Comsat
+      TARGET {}
+    }
     //Ground station performance data [4, p. 10-44]
     Antenna {
       TechLevel = 3
@@ -261,6 +285,18 @@ skopos_telecom {
     // ground.
     alt = 160
     role = trx
+    //C-band antenna in L-band for gameplay reasons
+    Antenna {
+      TechLevel = 3
+      RFBand = L (Wideband)     //just let RA autocalculate gain
+      referenceGain = 60
+      referenceFrequency = 4768
+      TxPower = 67.8
+      AMWTemp = 214     //230K-16K. Based on Syncom AN/FSC-9 terminals [4, p.8-10]. -16K for RA atmo noise
+      ModulationBits = 1  //FM, FSK or PSK only?
+      EncoderOverride = None - Early Comsat
+      TARGET {}
+    }
     //Ground station performance data [4, p.10-46]
     Antenna {
       TechLevel = 3
@@ -295,6 +331,18 @@ skopos_telecom {
     // ground.
     alt = 555
     role = trx
+    //C-band antenna in L-band for gameplay reasons
+    Antenna {
+      TechLevel = 3
+      RFBand = L (Wideband)     //just let RA autocalculate gain
+      referenceGain = 60
+      referenceFrequency = 4768
+      TxPower = 67.8
+      AMWTemp = 214     //230K-16K. Based on Syncom AN/FSC-9 terminals [4, p.8-10]. -16K for RA atmo noise
+      ModulationBits = 1  //FM, FSK or PSK only?
+      EncoderOverride = None - Early Comsat
+      TARGET {}
+    }
     //Assuming same as paumalu?
     Antenna {
       TechLevel = 3
@@ -329,6 +377,18 @@ skopos_telecom {
     // ground.
     alt = 355
     role = trx
+    //C-band antenna in L-band for gameplay reasons
+    Antenna {
+      TechLevel = 3
+      RFBand = L (Wideband)     //just let RA autocalculate gain
+      referenceGain = 60
+      referenceFrequency = 4768
+      TxPower = 67.8
+      AMWTemp = 214     //230K-16K. Based on Syncom AN/FSC-9 terminals [4, p.8-10]. -16K for RA atmo noise
+      ModulationBits = 1  //FM, FSK or PSK only?
+      EncoderOverride = None - Early Comsat
+      TARGET {}
+    }
     //Assuming same as paumalu?
     Antenna {
       TechLevel = 3
@@ -398,6 +458,18 @@ skopos_telecom {
     // ground.
     alt = 945
     role = trx
+    //Give Santa Paula the Southbury L-band dish too for gameplay reasons
+    Antenna {
+      TechLevel = 3
+      RFBand = L (Wideband)
+      referenceGain = 38
+      referenceFrequency = 1597.5
+      TxPower = 65
+      AMWTemp = 120
+      ModulationBits = 1  //FM, FSK or PSK only?
+      EncoderOverride = None - 70s Comsat
+      TARGET {}
+    }
     //Ground station performance data [12, p.252]
     Antenna {
       TechLevel = 3
@@ -1020,6 +1092,18 @@ skopos_telecom {
     // 2668 m ASL, + 30 m above the ground.
     alt = 2698
     role = trx
+    //C-band antenna in L-band for gameplay reasons
+    Antenna {
+      TechLevel = 3
+      RFBand = L (Wideband)     //just let RA autocalculate gain
+      referenceGain = 60
+      referenceFrequency = 4768
+      TxPower = 70
+      AMWTemp = 214     //230K-16K. Based on Syncom AN/FSC-9 terminals [4, p.8-10]. -16K for RA atmo noise
+      ModulationBits = 1  //FM, FSK or PSK only?
+      EncoderOverride = None - Early Comsat
+      TARGET {}
+    }
     Antenna {
       TechLevel = 3
       RFBand = C (Wideband)
@@ -1052,6 +1136,25 @@ skopos_telecom {
     // 2668 m ASL, + 30 m above the ground.
     alt = 2698
     role = trx
+    //C-band antenna in L-band for gameplay reasons
+    Antenna {
+      TechLevel = 3
+      RFBand = L (Wideband)     //just let RA autocalculate gain
+      referenceGain = 48.7
+      referenceFrequency = 4768
+      TxPower = 63
+      AMWTemp = 214     //230K-16K. Based on Syncom AN/FSC-9 terminals [4, p.8-10]. -16K for RA atmo noise
+      ModulationBits = 1  //FM, FSK or PSK only?
+      EncoderOverride = None - Early Comsat
+      TARGET {}
+      //Give L-band the larger antenna too
+      UPGRADE
+      {
+        TechLevel = 5           // Tangua station operational 1969
+        referenceGain = 60
+        TxPower = 70
+      }
+    }
     //Initial 30ft 1963 station, same as Fucino No. 1?
     Antenna {
       TechLevel = 3
@@ -1096,6 +1199,18 @@ skopos_telecom {
     // 1009 m ASL, + 30 m above the ground.
     alt = 1039
     role = trx
+    //C-band antenna in L-band for gameplay reasons
+    Antenna {
+      TechLevel = 3
+      RFBand = L (Wideband)     //just let RA autocalculate gain
+      referenceGain = 58.4
+      referenceFrequency = 4768
+      TxPower = 70
+      AMWTemp = 214     //230K-16K. Based on Syncom AN/FSC-9 terminals [4, p.8-10]. -16K for RA atmo noise
+      ModulationBits = 1  //FM, FSK or PSK only?
+      EncoderOverride = None - Early Comsat
+      TARGET {}
+    }
     //Ground station performance data [4, p. 10-44]
     Antenna {
       TechLevel = 3
@@ -1202,6 +1317,12 @@ skopos_telecom {
       ModulationBits = 1  //FM, FSK or PSK only?
       EncoderOverride = None - Early Comsat
       TARGET {}
+      //Give L-band the improved antenna too
+      UPGRADE
+      {
+        TechLevel = 4           // "Improved Comms" 1964-1966 tech node
+        referenceGain = 58.5
+      }
     }
     //original telstar performance [4, p.6-9]
     Antenna {
@@ -1244,6 +1365,24 @@ skopos_telecom {
     // 566 m ASL, + 27 m above the ground.
     alt = 593
     role = trx
+    //C-band antenna in L-band for gameplay reasons
+    Antenna {
+      TechLevel = 3
+      RFBand = L (Wideband)     //just let RA autocalculate gain
+      referenceGain = 48.7
+      referenceFrequency = 4768
+      TxPower = 63
+      AMWTemp = 214     //230K-16K. Based on Syncom AN/FSC-9 terminals [4, p.8-10]. -16K for RA atmo noise
+      ModulationBits = 1  //FM, FSK or PSK only?
+      EncoderOverride = None - Early Comsat
+      TARGET {}
+      //Give L-band the larger antenna too
+      UPGRADE
+      {
+        TechLevel = 4           // "Improved Comms" 1964-1966 tech node
+        referenceGain = 58.4    // 25 meter antenna
+      }
+    }
     //Ground station performance data [4]
     Antenna {
       TechLevel = 3
@@ -1286,6 +1425,30 @@ skopos_telecom {
     // 655 m ASL, + 30 m above the ground.
     alt = 685
     role = trx
+    //C-band antenna in L-band for gameplay reasons
+    Antenna {
+      TechLevel = 3
+      RFBand = L (Wideband)     //just let RA autocalculate gain
+      referenceGain = 48.7
+      referenceFrequency = 4768
+      TxPower = 63
+      AMWTemp = 214     //230K-16K. Based on Syncom AN/FSC-9 terminals [4, p.8-10]. -16K for RA atmo noise
+      ModulationBits = 1  //FM, FSK or PSK only?
+      EncoderOverride = None - Early Comsat
+      TARGET {}
+      //Give L-band the larger antenna too
+      UPGRADE
+      {
+        TechLevel = 4           // "Improved Comms" 1964-1966 tech node
+        referenceGain = 52.14
+      }
+      UPGRADE
+      {
+        TechLevel = 5    //1967, 27m antenna for Intelsat II [4, p.10-46]
+        referenceGain = 59.9
+        TxPower = 68
+      }
+    }
     //Ground station performance data [4]
     Antenna {
       TechLevel = 3
@@ -1346,6 +1509,13 @@ skopos_telecom {
       ModulationBits = 1  //FM, FSK or PSK only?
       EncoderOverride = None - Early Comsat
       TARGET {}
+      //Give L-band the larger antenna too
+      UPGRADE
+      {
+        TechLevel = 5           // "Advanced Comms" 1967-1971 tech node (1967-1970)
+        referenceGain = 60
+        referenceFrequency = 4768
+      }
     }
     //10 m antenna operating in C-band (ahistorical, but filling in for various other Japanese stations)
     Antenna {
@@ -1374,6 +1544,31 @@ skopos_telecom {
     lon = 140.373138
     alt = 70
     role = trx
+    //C-band antenna in L-band for gameplay reasons
+    Antenna {
+      TechLevel = 3
+      RFBand = L (Wideband)     //just let RA autocalculate gain
+      referenceGain = 56.4
+      referenceFrequency = 4768
+      TxPower = 63
+      AMWTemp = 214     //230K-16K. Based on Syncom AN/FSC-9 terminals [4, p.8-10]. -16K for RA atmo noise
+      ModulationBits = 1  //FM, FSK or PSK only?
+      EncoderOverride = None - Early Comsat
+      TARGET {}
+      //Give L-band the larger antenna too
+      UPGRADE
+      {
+        TechLevel = 5         // "Advanced Comms" 1967-1971 tech node (1967-1970)
+        referenceGain = 58.5
+        TxPower = 70
+      }
+      UPGRADE
+      {
+        TechLevel = 6
+        referenceGain = 60
+        TxPower = 67.8
+      }
+    }
     //Original 20-meter antenna for Relay program, 1963 [4, p.7-3]
     //Assuming similar to Raisting No. 2, most similar documented antenna from Relay [4, p.7-8]
     Antenna {
@@ -1426,6 +1621,18 @@ skopos_telecom {
     // ground.
     alt = 506
     role = trx
+    //C-band antenna in L-band for gameplay reasons
+    Antenna {
+      TechLevel = 3
+      RFBand = L (Wideband)     //just let RA autocalculate gain
+      referenceGain = 60
+      referenceFrequency = 4768
+      TxPower = 70
+      AMWTemp = 214     //230K-16K. Based on Syncom AN/FSC-9 terminals [4, p.8-10]. -16K for RA atmo noise
+      ModulationBits = 1  //FM, FSK or PSK only?
+      EncoderOverride = None - Early Comsat
+      TARGET {}
+    }
     Antenna {
       TechLevel = 3
       RFBand = C (Wideband)
@@ -1459,6 +1666,18 @@ skopos_telecom {
     // ground.
     alt = 35
     role = trx
+    //C-band antenna in L-band for gameplay reasons
+    Antenna {
+      TechLevel = 3
+      RFBand = L (Wideband)     //just let RA autocalculate gain
+      referenceGain = 60
+      referenceFrequency = 4768
+      TxPower = 70
+      AMWTemp = 214     //230K-16K. Based on Syncom AN/FSC-9 terminals [4, p.8-10]. -16K for RA atmo noise
+      ModulationBits = 1  //FM, FSK or PSK only?
+      EncoderOverride = None - Early Comsat
+      TARGET {}
+    }
     //Ground station performance data [4]
     Antenna {
       TechLevel = 3
@@ -1493,6 +1712,23 @@ skopos_telecom {
     // ground.
     alt = 87
     role = trx
+    //C-band antenna in L-band for gameplay reasons
+    Antenna {
+      TechLevel = 3
+      RFBand = L (Wideband)     //just let RA autocalculate gain
+      antennaDiameter = 12.8
+      TxPower = 70
+      AMWTemp = 214     //230K-16K. Based on Syncom AN/FSC-9 terminals [4, p.8-10]. -16K for RA atmo noise
+      ModulationBits = 1  //FM, FSK or PSK only?
+      EncoderOverride = None - Early Comsat
+      TARGET {}
+      //Give L-band the larger antenna too
+      UPGRADE
+      {
+        TechLevel = 5           // "Advanced Comms" 1967-1971 tech node (1967-1970)
+        antennaDiameter = 29.57
+      }
+    }
     //Ground station performance data [4]
     Antenna {
       TechLevel = 3
@@ -1534,6 +1770,18 @@ skopos_telecom {
     // ground.
     alt = 140
     role = trx
+    //C-band antenna in L-band for gameplay reasons
+    Antenna {
+      TechLevel = 3
+      RFBand = L (Wideband)     //just let RA autocalculate gain
+      referenceGain = 60
+      referenceFrequency = 4768
+      TxPower = 70
+      AMWTemp = 214     //230K-16K. Based on Syncom AN/FSC-9 terminals [4, p.8-10]. -16K for RA atmo noise
+      ModulationBits = 1  //FM, FSK or PSK only?
+      EncoderOverride = None - Early Comsat
+      TARGET {}
+    }
     //Ground station performance data [4]
     Antenna {
       TechLevel = 3
@@ -1568,6 +1816,18 @@ skopos_telecom {
     // ground.
     alt = 145
     role = trx
+    //C-band antenna in L-band for gameplay reasons
+    Antenna {
+      TechLevel = 3
+      RFBand = L (Wideband)     //just let RA autocalculate gain
+      referenceGain = 60
+      referenceFrequency = 4768
+      TxPower = 70
+      AMWTemp = 214     //230K-16K. Based on Syncom AN/FSC-9 terminals [4, p.8-10]. -16K for RA atmo noise
+      ModulationBits = 1  //FM, FSK or PSK only?
+      EncoderOverride = None - Early Comsat
+      TARGET {}
+    }
     //Ground station performance data [4]
     Antenna {
       TechLevel = 3
@@ -1605,6 +1865,24 @@ skopos_telecom {
     // ground.
     alt = 44
     role = trx
+    //C-band antenna in L-band for gameplay reasons
+    Antenna {
+      TechLevel = 3
+      RFBand = L (Wideband)     //just let RA autocalculate gain
+      referenceGain = 54
+      referenceFrequency = 4768
+      TxPower = 63
+      AMWTemp = 214     //230K-16K. Based on Syncom AN/FSC-9 terminals [4, p.8-10]. -16K for RA atmo noise
+      ModulationBits = 1  //FM, FSK or PSK only?
+      EncoderOverride = None - Early Comsat
+      TARGET {}
+      //Give L-band the larger antenna too
+      UPGRADE
+      {
+        TechLevel = 5           // "Advanced Comms" 1967-1971 tech node (1967-1970)
+        referenceGain = 60      // same as Paumalu, 30 meter antenna
+      }
+    }
     //Ground station performance data [4]
     Antenna {
       TechLevel = 3
@@ -1647,6 +1925,18 @@ skopos_telecom {
     // ground.
     alt = 557
     role = trx
+    //C-band antenna in L-band for gameplay reasons
+    Antenna {
+      TechLevel = 3
+      RFBand = L (Wideband)     //just let RA autocalculate gain
+      referenceGain = 51.5
+      referenceFrequency = 4768
+      TxPower = 63
+      AMWTemp = 214     //230K-16K. Based on Syncom AN/FSC-9 terminals [4, p.8-10]. -16K for RA atmo noise
+      ModulationBits = 1  //FM, FSK or PSK only?
+      EncoderOverride = None - Early Comsat
+      TARGET {}
+    }
     //Ground station performance data [4, p.13-16]
     Antenna {
       TechLevel = 3
@@ -1669,6 +1959,18 @@ skopos_telecom {
     // ground.
     alt = 220
     role = trx
+    //C-band antenna in L-band for gameplay reasons
+    Antenna {
+      TechLevel = 3
+      RFBand = L (Wideband)     //just let RA autocalculate gain
+      referenceGain = 60
+      referenceFrequency = 4768
+      TxPower = 67.8
+      AMWTemp = 214     //230K-16K. Based on Syncom AN/FSC-9 terminals [4, p.8-10]. -16K for RA atmo noise
+      ModulationBits = 1  //FM, FSK or PSK only?
+      EncoderOverride = None - Early Comsat
+      TARGET {}
+    }
     //Moree brought online 1968 with 92ft antenna [4, p.10-14]
     //Same as Paumalu, 30(ish) meter antenna
     Antenna {
@@ -1702,6 +2004,18 @@ skopos_telecom {
     lon = 166.6625901
     alt = 50
     role = trx
+    //C-band antenna in L-band for gameplay reasons
+    Antenna {
+      TechLevel = 3
+      RFBand = L (Wideband)     //just let RA autocalculate gain
+      referenceGain = 39
+      referenceFrequency = 4768
+      TxPower = 43
+      AMWTemp = 214     //230K-16K. Based on Syncom AN/FSC-9 terminals [4, p.8-10]. -16K for RA atmo noise
+      ModulationBits = 1  //FM, FSK or PSK only?
+      EncoderOverride = None - Early Comsat
+      TARGET {}
+    }
     //Ground station performance data [4, p.10-59]
     Antenna {
       TechLevel = 3
@@ -1789,6 +2103,18 @@ skopos_telecom {
     lon = 2.541923
     alt = 1270
     role = trx
+    //C-band antenna in L-band for gameplay reasons
+    Antenna {
+      TechLevel = 3
+      RFBand = L (Wideband)     //just let RA autocalculate gain
+      referenceGain = 49
+      referenceFrequency = 4768
+      TxPower = 60
+      AMWTemp = 214     //230K-16K. Based on Syncom AN/FSC-9 terminals [4, p.8-10]. -16K for RA atmo noise
+      ModulationBits = 1  //FM, FSK or PSK only?
+      EncoderOverride = None - Early Comsat
+      TARGET {}
+    }
     //Ground station performance data estimated
     Antenna {
       TechLevel = 3
@@ -1858,6 +2184,18 @@ skopos_telecom {
     // ground.
     alt = 1745
     role = trx
+    //C-band antenna in L-band for gameplay reasons
+    Antenna {
+      TechLevel = 3
+      RFBand = L (Wideband)     //just let RA autocalculate gain
+      referenceGain = 60
+      referenceFrequency = 4768
+      TxPower = 70
+      AMWTemp = 214     //230K-16K. Based on Syncom AN/FSC-9 terminals [4, p.8-10]. -16K for RA atmo noise
+      ModulationBits = 1  //FM, FSK or PSK only?
+      EncoderOverride = None - Early Comsat
+      TARGET {}
+    }
     //Ground station performance data [4]
     Antenna {
       TechLevel = 3
@@ -1906,6 +2244,13 @@ skopos_telecom {
       ModulationBits = 1  //FM, FSK or PSK only?
       EncoderOverride = None - Early Comsat
       TARGET {}
+      //Give L-band the bigger antenna too
+      UPGRADE
+      {
+        TechLevel = 6
+        referenceGain = 60
+        referenceFrequency = 4768
+        TxPower = 70
     }
     //Ground station performance data [4, p.11-16]
     Antenna {
@@ -2258,6 +2603,19 @@ skopos_telecom {
     // Elevation 37 m
     alt = 57
     role = rx
+    //C-band antenna in L-band for gameplay reasons
+    Antenna {
+      TechLevel = 3
+      RFBand = L (Wideband)     //just let RA autocalculate gain
+      referenceGain = 37.5        //same antenna as C-band, just operating in L-band
+      referenceFrequency = 4768
+      // Rx only, just make sure RA connects.
+      TxPower = 120.828  // 1.21 GW!
+      AMWTemp = 200
+      ModulationBits = 1  //FM, FSK or PSK only?
+      EncoderOverride = None - Early Comsat
+      TARGET {}
+    }
     //Ground station performance data [5, p.VI-3]
     //Moskva station
     Antenna {
@@ -2294,6 +2652,19 @@ skopos_telecom {
     // Elevation 101 m
     alt = 121
     role = rx
+    //C-band antenna in L-band for gameplay reasons
+    Antenna {
+      TechLevel = 3
+      RFBand = L (Wideband)     //just let RA autocalculate gain
+      referenceGain = 37.5        //same antenna as C-band, just operating in L-band
+      referenceFrequency = 4768
+      // Rx only, just make sure RA connects.
+      TxPower = 120.828  // 1.21 GW!
+      AMWTemp = 200
+      ModulationBits = 1  //FM, FSK or PSK only?
+      EncoderOverride = None - Early Comsat
+      TARGET {}
+    }
     //Ground station performance data [5, p.VI-3]
     //Moskva station
     Antenna {
@@ -2330,6 +2701,19 @@ skopos_telecom {
     // Elevation 40 m
     alt = 60
     role = rx
+    //C-band antenna in L-band for gameplay reasons
+    Antenna {
+      TechLevel = 3
+      RFBand = L (Wideband)     //just let RA autocalculate gain
+      referenceGain = 37.5        //same antenna as C-band, just operating in L-band
+      referenceFrequency = 4768
+      // Rx only, just make sure RA connects.
+      TxPower = 120.828  // 1.21 GW!
+      AMWTemp = 200
+      ModulationBits = 1  //FM, FSK or PSK only?
+      EncoderOverride = None - Early Comsat
+      TARGET {}
+    }
     //Ground station performance data [5, p.VI-3]
     //Moskva station
     Antenna {
@@ -2366,6 +2750,19 @@ skopos_telecom {
     // Elevation 6 m
     alt = 26
     role = rx
+    //C-band antenna in L-band for gameplay reasons
+    Antenna {
+      TechLevel = 3
+      RFBand = L (Wideband)     //just let RA autocalculate gain
+      referenceGain = 37.5        //same antenna as C-band, just operating in L-band
+      referenceFrequency = 4768
+      // Rx only, just make sure RA connects.
+      TxPower = 120.828  // 1.21 GW!
+      AMWTemp = 200
+      ModulationBits = 1  //FM, FSK or PSK only?
+      EncoderOverride = None - Early Comsat
+      TARGET {}
+    }
     //Ground station performance data [5, p.VI-3]
     //Moskva station
     Antenna {
@@ -3045,6 +3442,18 @@ skopos_telecom {
     // ground.
     alt = 75
     role = trx
+    //Give Santa Paula the Southbury L-band dish too for gameplay reasons
+    Antenna {
+      TechLevel = 3
+      RFBand = L (Wideband)
+      referenceGain = 38
+      referenceFrequency = 1597.5
+      TxPower = 65
+      AMWTemp = 120
+      ModulationBits = 1  //FM, FSK or PSK only?
+      EncoderOverride = None - 70s Comsat
+      TARGET {}
+    }
     //Ground station performance data [12, p.252]
     //~14 meter antennas. Same as Marisat stations?
     Antenna {
@@ -3068,6 +3477,18 @@ skopos_telecom {
     // ground.
     alt = 105
     role = trx
+    //Give Santa Paula the Southbury L-band dish too for gameplay reasons
+    Antenna {
+      TechLevel = 3
+      RFBand = L (Wideband)
+      referenceGain = 38
+      referenceFrequency = 1597.5
+      TxPower = 65
+      AMWTemp = 120
+      ModulationBits = 1  //FM, FSK or PSK only?
+      EncoderOverride = None - 70s Comsat
+      TARGET {}
+    }
     //Ground station performance data [12, p.252]
     //~14 meter antennas. Same as Marisat stations?
     Antenna {
@@ -3217,6 +3638,18 @@ skopos_telecom {
     // 30 m ASL?
     alt = 30
     role = trx
+    //Give Kingsport L-band antenna too for gameplay reasons
+    Antenna {
+      TechLevel = 3
+      RFBand = L (Wideband)
+      referenceGain = 40
+      referenceFrequency = 1597.5
+      TxPower = 70  //20 kW peak, 10 kW continuous
+      AMWTemp = 200
+      ModulationBits = 1  //FM, FSK or PSK only?
+      EncoderOverride = None - Early Comsat
+      TARGET {}
+    }
     //Ground station performance data [4, p.10-44]
     Antenna {
       TechLevel = 3
@@ -3277,6 +3710,18 @@ skopos_telecom {
     // 30 m ASL?
     alt = 30
     role = trx
+    //Give Kingsport L-band antenna too for gameplay reasons
+    Antenna {
+      TechLevel = 3
+      RFBand = L (Wideband)
+      referenceGain = 40
+      referenceFrequency = 1597.5
+      TxPower = 70  //20 kW peak, 10 kW continuous
+      AMWTemp = 200
+      ModulationBits = 1  //FM, FSK or PSK only?
+      EncoderOverride = None - Early Comsat
+      TARGET {}
+    }
     //Ground station performance data [4, p.10-44]
     Antenna {
       TechLevel = 3
@@ -3337,6 +3782,18 @@ skopos_telecom {
     // 30 m ASL?
     alt = 30
     role = trx
+    //Give Kingsport L-band antenna too for gameplay reasons
+    Antenna {
+      TechLevel = 3
+      RFBand = L (Wideband)
+      referenceGain = 40
+      referenceFrequency = 1597.5
+      TxPower = 70  //20 kW peak, 10 kW continuous
+      AMWTemp = 200
+      ModulationBits = 1  //FM, FSK or PSK only?
+      EncoderOverride = None - Early Comsat
+      TARGET {}
+    }
     //Ground station performance data [4, p.10-44]
     Antenna {
       TechLevel = 3


### PR DESCRIPTION
Due to player complaints, add L-band antennas (just using C-band antennas set to L-band) to most early satellite earth stations. This gives the player more flexibility and doesn't punish them as badly for building their first satellites in L-band.

Intelsat, Inmarsat, and Moskva satellite earth stations that previously only accepted C-band have had L-band antennas added. 70s commercial stations do not get L-band because you could not complete their associated contracts within the bandwidth limitations of L-band even if you wanted to.

L-band only stations (Marisat mobile terminals, Ekran recievers, etc.) will not receive antennas in other bands because their band limitations are part of the challenge of serving them, and due to historical technological limitations.