### PR TITLE
Fix typo in L3 pacific connection name

### DIFF
--- a/GameData/Skopos/telecom.cfg
+++ b/GameData/Skopos/telecom.cfg
@@ -4621,7 +4621,7 @@ skopos_telecom {
     exclusive = true
   }
   connection {
-    name = l3_pacific_poi_yan
+    name = l3_pacific_jam_yan
     trx = jamesburg
     trx = yangmingshang
     latency = 0.80


### PR DESCRIPTION
Fix a connection in the level 3 Pacific series using the old name, preventing the contract from loading