### PR TITLE
Allow inconsistent encodings on broadcast

### DIFF
--- a/Telecom/routing.cs
+++ b/Telecom/routing.cs
@@ -314,23 +314,6 @@ namespace σκοπός {
 
         var link = OrientedLink.Get(this, from: tx, to: rx);
 
-        if (is_point_to_multipoint &&
-            !multiple_tracking_.Contains(tx) &&
-            !link.is_at_tx_tech_level) {
-          // DRVeyl says: RA kindly assumes higher-tech equipment can
-          // automatically realize it should run an earlier encoding!
-          // We are less kind than that when broadcasting, because then the
-          // lower-tech links would be incompatible with the higher-tech ones.
-          // We could get away with just using the links at a given tech level,
-          // e.g., the max or the min available, but then existing links would
-          // become ineligible when adding a receiver, which would be deeply
-          // confusing.  Intsead we just assume that along a broadcast channel,
-          // everything but fancy Earth stations simply transmits using an
-          // encoding and a modulation predetermined at construction.
-          // For point-to-point connections we retain the RA kindness.
-          continue;
-        }
-
         if (link.CapacityWithUsage(usage) < data_rate) {
           continue;
         }


### PR DESCRIPTION
1. When this limitation is hit, the connection inspector does not know how to explain it, and produces confusing reports that the connection is limited by both latency and data rate, but then stating that it would be available at a higher data rate and a lower latency than those required:
   | Screenshot from dengmahal | Screenshot from Ballatik |
   |---|---|
   | ![image](https://github.com/user-attachments/assets/37f71e70-2ae3-43b0-9465-fb6f9d519c0d) | ![screenshot1](https://github.com/user-attachments/assets/57327980-a653-49ab-a4e8-78260f4831fa) |
2. The limitation is too strong: surely the operators of an overly modern satellite would pick an earlier encoding if it can reach all necessary receivers.

Fixing this properly (#49) is algorithmically tricky: for each transmitter, we would have to choose an encoding, which would determine the possible receivers. The set of choices of encoding that lead to reaching the most final receivers would then be picked.

Even trickier would be explaining the result of this algorithm in the connection inspector when the limit is hit.

For now, allowing unphysical mixed-encoding broadcast may be OK, since it seems unlikely to happen in practice on the early contracts.

See also the discussion here https://discord.com/channels/319857228905447436/982749809482027129/1368236895204806748.