### PR TITLE
Initialization Fixes

### DIFF
--- a/Telecom/main_window.cs
+++ b/Telecom/main_window.cs
@@ -15,6 +15,10 @@ internal class MainWindow : principia.ksp_plugin_adapter.SupervisedWindowRendere
   protected override string Title => "Σκοπός Telecom network overview";
 
   protected override void RenderWindowContents(int window_id) {
+    if (!telecom_.enabled || telecom_.network == null) {
+      UnityEngine.GUILayout.Label("Please wait for the Σκοπός Telecom network to initialize...");
+      return;
+    }
     using (new UnityEngine.GUILayout.VerticalScope()) {
       show_network = UnityEngine.GUILayout.Toggle(show_network, "Show network");
       var inspected_connections = connection_inspectors_.Keys.ToArray();

--- a/Telecom/network.cs
+++ b/Telecom/network.cs
@@ -45,6 +45,7 @@ namespace σκοπός {
         connections_[node.GetValue("name")].Load(node);
       }
       ReloadContractConnections();
+      (CommNet.CommNetScenario.Instance as RACommNetScenario).Network.InvalidateCache();    // Inform RA of changes to the node list.
     }
 
     public void Serialize(ConfigNode node) {
@@ -205,6 +206,7 @@ namespace σκοπός {
           contract_connections.Add(GetConnection(connection.connection_name));
         }
       }
+      (CommNet.CommNetScenario.Instance as RACommNetScenario).Network.InvalidateCache();    // Inform RA of changes to the node list.
     }
     public IEnumerable<Connection> connections => connections_.Values;
 

--- a/Telecom/network.cs
+++ b/Telecom/network.cs
@@ -1,8 +1,6 @@
 ﻿using RealAntennas;
 using RealAntennas.MapUI;
 using RealAntennas.Network;
-using RealAntennas.Targeting;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -46,6 +44,7 @@ namespace σκοπός {
       foreach (ConfigNode node in connection_nodes) {
         connections_[node.GetValue("name")].Load(node);
       }
+      ReloadContractConnections();
     }
 
     public void Serialize(ConfigNode node) {
@@ -68,7 +67,7 @@ namespace σκοπός {
           continue;
         }
         Telecom.Log($"Adding station {name}");
-        stations_.Add(name, null);
+        stations_.Add(name, MakeStation(name));
       }
     }
 
@@ -98,6 +97,11 @@ namespace σκοπός {
         station_node.AddNode(antenna);
       }
       station.Configure(station_node, body);
+      if (RACommNetScenario.GroundStations.TryGetValue(station.nodeName, out RACommNetHome oldStation)) { 
+        RACommNetScenario.GroundStations.Remove(station.nodeName);
+        UnityEngine.Object.Destroy(oldStation);
+      }
+      RACommNetScenario.GroundStations.Add(station.nodeName, station);
 
       if (node.GetValue("role") == "tx") {
         tx_only_.Add(station);
@@ -128,28 +132,16 @@ namespace σκοπός {
       iconData.visible &= !hide_off_network;
     }
 
-    public void Refresh() {
-      bool all_stations_good = true;;
-      var station_names = stations_.Keys.ToArray();
-      foreach (var name in station_names) {
-        if (stations_[name] == null) {
-          Telecom.Log($"Making station {name}");
-          stations_[name] = MakeStation(name);
-        }
-        if (stations_[name].Comm == null) {
-          Telecom.Log($"null Comm for {name}");
-          all_stations_good = false;
-        }
-        string node_name = stations_[name].nodeName;
-        if (!RACommNetScenario.GroundStations.ContainsKey(node_name)) {
-          Telecom.Log($"{name} not in GroundStations at {node_name}");
-          RACommNetScenario.GroundStations.Add(node_name, stations_[name]);
-        } else if (RACommNetScenario.GroundStations[node_name] != stations_[name]) {
-          Telecom.Log($"{name} is not GroundStations[{node_name}]");
-          UnityEngine.Object.DestroyImmediate(RACommNetScenario.GroundStations[node_name]);
-          RACommNetScenario.GroundStations[node_name] = stations_[name];
+    private void StationSanityChecker() { 
+      foreach (var pair in stations_) {
+        var station = pair.Value;
+        if (station.Comm.RAAntennaList.Count == 0) {
+          Telecom.Log($"No antenna for {pair.Key}; Ground TL is {RACommNetScenario.GroundStationTechLevel}");
         }
       }
+    }
+
+    internal void UpdateStationVisibilityHandler() { 
       if (RACommNetUI.Instance is RACommNetUI ui) {
         foreach (var site in ui.groundStationSiteNodes) {
           var station_comm = ((GroundStationSiteNode)site.siteObject).node;
@@ -163,16 +155,9 @@ namespace σκοπός {
           }
         }
       }
-      if (!all_stations_good) {
-        return;
-      }
-      foreach (var pair in stations_) {
-        var station = pair.Value;
-        if (station.Comm.RAAntennaList.Count == 0) {
-          Telecom.Log($"No antenna for {pair.Key}");
-          Telecom.Log($"Ground TL is {RACommNetScenario.GroundStationTechLevel}");
-        }
-      }
+    }
+
+    public void Refresh() {
 
       UpdateConnections();
       foreach (RealAntennaDigital antenna in routing_.usage.Transmitters()) {
@@ -198,24 +183,6 @@ namespace σκοπός {
           from station in tx_only_ select station.Comm,
           from station in rx_only_ select station.Comm,
           from station in stations_.Values select station.Comm);
-      connections_by_contract.Clear();
-      contracted_connections.Clear();
-      foreach (var contract in Contracts.ContractSystem.Instance.Contracts) {
-        if (contract.ContractState == Contracts.Contract.State.Active) {
-          List<Connection> contract_connections = null;
-          foreach (var parameter in contract.AllParameters) {
-            if (parameter is ConnectionAvailability connection) {
-              if (contract_connections == null &&
-                  !connections_by_contract.TryGetValue(contract, out contract_connections)) {
-                contract_connections = new List<Connection>();
-                connections_by_contract.Add(contract, contract_connections);
-              }
-              contracted_connections.Add(GetConnection(connection.connection_name));
-              contract_connections.Add(GetConnection(connection.connection_name));
-            }
-          }
-        }
-      }
       foreach (var connection in connections_.Values) {
         if (contracted_connections.Contains(connection)) {
           connection.AttemptConnection(routing_, this, Telecom.Instance.last_universal_time);
@@ -223,6 +190,22 @@ namespace σκοπός {
       }
     }
 
+    internal void ReloadContractConnections() {
+      connections_by_contract.Clear();
+      contracted_connections.Clear();
+      foreach (var contract in Contracts.ContractSystem.Instance.Contracts.Where(c => c.ContractState == Contracts.Contract.State.Active)) {
+        List<Connection> contract_connections = null;
+        foreach (ConnectionAvailability connection in contract.AllParameters.Where(p => p is ConnectionAvailability)) {
+          if (contract_connections == null &&
+              !connections_by_contract.TryGetValue(contract, out contract_connections)) {
+            contract_connections = new List<Connection>();
+            connections_by_contract.Add(contract, contract_connections);
+          }
+          contracted_connections.Add(GetConnection(connection.connection_name));
+          contract_connections.Add(GetConnection(connection.connection_name));
+        }
+      }
+    }
     public IEnumerable<Connection> connections => connections_.Values;
 
     public Connection GetConnection(string name) {

--- a/Telecom/telecom.cs
+++ b/Telecom/telecom.cs
@@ -5,6 +5,7 @@ using RealAntennas;
 using RealAntennas.MapUI;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Collections;
 
 namespace σκοπός {
   [KSPScenario(
@@ -23,25 +24,76 @@ namespace σκοπός {
       UnityEngine.Debug.Log($"[Σκοπός Telecom]: {message} ({file}:{line})");
     }
 
-    public Telecom() {
-      Log("Constructor");
+    public override void OnAwake() {
+      Log($"Scenario Module OnAwake in {HighLogic.LoadedScene}.");
       Instance = this;
       main_window_ = new MainWindow(this);
     }
 
     public override void OnLoad(ConfigNode node) {
-      Log("OnLoad");
-      base.OnLoad(node);
-      network = new Network(node.GetNode("network"));
+      config = node.GetNode("network") ?? new ConfigNode();
     }
 
     public override void OnSave(ConfigNode node) {
-      Log("OnSave");
       base.OnSave(node);
-      network.Serialize(node.AddNode("network"));
+      if (network == null) {
+        node.AddNode("network", config);
+      } else {
+        network.Serialize(node.AddNode("network"));
+      }
+    }
+
+    public void Start() {
+      Log("Starting");
+      enabled = false;
+      GameEvents.CommNet.OnNetworkInitialized.Add(NetworkInitializedNotify);
+      StartCoroutine(CreateNetwork());
+    }
+
+    public void OnDestroy() {
+      Log("Destroying");
+      GameEvents.CommNet.OnNetworkInitialized.Remove(NetworkInitializedNotify);
+      GameEvents.Contract.onAccepted.Remove(OnContractsChanged);
+      GameEvents.Contract.onFinished.Remove(OnContractsChanged);    
+    }
+
+    private void NetworkInitializedNotify() {
+      Log("CommNet Network Initialization fired.");
+    }
+
+    private IEnumerator CreateNetwork() {
+      while (RACommNetScenario.RACN == null || !CommNet.CommNetNetwork.Initialized) {
+          yield return new UnityEngine.WaitForFixedUpdate();
+      }
+      Log("Creating Network");
+      network = new Network(config);
+      (CommNet.CommNetScenario.Instance as RACommNetScenario).Network.InvalidateCache();    // Inform RA of changes to the node list.
+      enabled = true;
+      GameEvents.Contract.onAccepted.Add(OnContractsChanged);
+      GameEvents.Contract.onFinished.Add(OnContractsChanged);
+      while (network.AllGround().Any(x => x.Comm == null)) {
+        yield return new UnityEngine.WaitForEndOfFrame();
+      }
+      network.UpdateStationVisibilityHandler();
+    }
+
+    private bool on_contracts_changed_cr_running = false;
+    internal void OnContractsChanged(Contracts.Contract data) {
+      if (!on_contracts_changed_cr_running) {
+        StartCoroutine(OnContractsChangedCR(data));
+      }
+    }
+
+    private IEnumerator OnContractsChangedCR(Contracts.Contract data) {
+      on_contracts_changed_cr_running = true;
+      yield return new UnityEngine.WaitForEndOfFrame();
+      network.ReloadContractConnections();
+      (CommNet.CommNetScenario.Instance as RACommNetScenario).Network.InvalidateCache();    // Inform RA of changes to the node list.
+      on_contracts_changed_cr_running = false;
     }
 
     private void OnGUI() {
+      if (!enabled) return;
       if (KSP.UI.Screens.ApplicationLauncher.Ready && toolbar_button_ == null) {
         LoadTextureIfExists(out UnityEngine.Texture toolbar_button_texture,
                             "skopos_telecom.png");
@@ -148,6 +200,7 @@ namespace σκοπός {
     public static Telecom Instance { get; private set; }
 
     public Network network { get; private set; }
+    private ConfigNode config;
     [KSPField(isPersistant = true)]
     internal MainWindow main_window_;
     public double last_universal_time => ut_;


### PR DESCRIPTION
Fix issues with initialization and FixedUpdate runtime performance.

Important: Always invalidate RealAntennas cache after changing the network nodes!  RA has an optimization of caching all of the network nodes/antennas in the gameworld, and requires a call to invalidate that cache.

Delay initialization until after RA network is alive to avoid a race condition with inserting Skopos stations
Use Unity calls (Start,OnDestroy) but KSP.OnAwake because KSP.ScenarioModule.Awake is private and important.
Detect contract changes via event handlers instead of enumerating the contract universe in FixedUpdate
Fully initialize stations when creating them.
Add stations into RA's GroundStations list.
Remove unnecessary FixedUpdate status scans of all stations and contracts.  Non-lazy generation of stations means we can avoid re-checking them.  Event handler tracks contracts.

Fixes #5 
Likely fixes #53 