### PR TITLE
Small Fixes

### DIFF
--- a/Telecom/connection_availability.cs
+++ b/Telecom/connection_availability.cs
@@ -138,6 +138,9 @@ namespace σκοπός {
 
     protected override void OnUpdate() {
       base.OnUpdate();
+      if (goal_ == Goal.MAINTAIN) {
+        monitor?.AlertIfNeeded();
+      }
       if (subparameters != null) {
         bool any_failed = false;
         bool any_incomplete = false;
@@ -244,9 +247,6 @@ namespace σκοπός {
             $"{pretty_latency}.\n{status}, {monitor.description}.\n" +
             $"Availability: {metric.description}\nTarget: {availability_:P2}";
         
-      }
-      if (goal_ == Goal.MAINTAIN) {
-        monitor?.AlertIfNeeded();
       }
       title_tracker_.Add(title);
       if (last_title_ != title) {

--- a/Telecom/ground_segment_mutation.cs
+++ b/Telecom/ground_segment_mutation.cs
@@ -100,7 +100,7 @@ namespace σκοπός {
         Telecom.Instance.network.AddStations(stations_);
         Telecom.Instance.network.AddConnections(connections_);
       }
-      Telecom.Instance.network.ReloadContractConnections();
+      Telecom.Instance.ReloadContractConnections(null);
     }
 
     private Operation operation_;

--- a/Telecom/ground_segment_mutation.cs
+++ b/Telecom/ground_segment_mutation.cs
@@ -100,7 +100,7 @@ namespace σκοπός {
         Telecom.Instance.network.AddStations(stations_);
         Telecom.Instance.network.AddConnections(connections_);
       }
-      Telecom.Instance.network.Refresh();
+      Telecom.Instance.network.ReloadContractConnections();
     }
 
     private Operation operation_;

--- a/Telecom/main_window.cs
+++ b/Telecom/main_window.cs
@@ -19,8 +19,21 @@ internal class MainWindow : principia.ksp_plugin_adapter.SupervisedWindowRendere
       UnityEngine.GUILayout.Label("Please wait for the Σκοπός Telecom network to initialize...");
       return;
     }
+    if (string.IsNullOrEmpty(alert_rate_limit_text)) {
+      alert_rate_limit_text = telecom_.max_alert_rate_in_days_.ToString();
+    }   // MainWindow initialization is before this field was loaded by the scenario.
+
     using (new UnityEngine.GUILayout.VerticalScope()) {
-      show_network = UnityEngine.GUILayout.Toggle(show_network, "Show network");
+      using (new UnityEngine.GUILayout.HorizontalScope()) {
+        show_network = UnityEngine.GUILayout.Toggle(show_network, "Show network");
+        telecom_.stop_warp_in_sim_ = UnityEngine.GUILayout.Toggle(telecom_.stop_warp_in_sim_, "Alerts stop warp in RP-1 sim");
+      }
+      using (new UnityEngine.GUILayout.HorizontalScope()) {
+        UnityEngine.GUILayout.Label("Suppress duplicate SLA alerts within");
+        alert_rate_limit_text = UnityEngine.GUILayout.TextField(alert_rate_limit_text);
+        double.TryParse(alert_rate_limit_text, out telecom_.max_alert_rate_in_days_);
+        UnityEngine.GUILayout.Label($"days ({telecom_.max_alert_rate_in_days_})");
+      }
       var inspected_connections = connection_inspectors_.Keys.ToArray();
       foreach (var inspected_connection in inspected_connections) {
         if (!telecom_.network.contracted_connections.Contains(inspected_connection)) {
@@ -114,6 +127,7 @@ internal class MainWindow : principia.ksp_plugin_adapter.SupervisedWindowRendere
     antenna_inspectors_;
 
   private Telecom telecom_;
+  private string alert_rate_limit_text;
   private readonly Dictionary<Contracts.Contract, bool> open_contracts_ =
       new Dictionary<Contracts.Contract, bool>();
   private readonly Dictionary<Connection, ConnectionInspector> connection_inspectors_ =

--- a/Telecom/monitor.cs
+++ b/Telecom/monitor.cs
@@ -9,39 +9,41 @@
     }
 
     public void AlertIfNeeded() {
+      var telecom = Telecom.Instance;
       if (metric_.availability >= availability_threshold_) {
-        if (alerted_) {
+        if (alerted_ && (telecom.last_universal_time > last_restore_time_ + telecom.max_alert_rate_in_days_ * 86400)) {
           alerted_ = false;
+          last_restore_time_ = telecom.last_universal_time;
           ScreenMessages.PostScreenMessage(
               $@"{service_name_}: availability is back to normal",
               30, ScreenMessageStyle.UPPER_CENTER, XKCDColors.Pear);
           KSP.UI.Screens.MessageSystem.Instance.AddMessage(
               new KSP.UI.Screens.MessageSystem.Message(
                   messageTitle: $"{service_name_} is back to normal",
-                  message: $@"The availability is {metric_.description
-              }, back above the target of {availability_threshold_:P2}.",
+                  message: $@"The availability is {metric_.description}, back above the target of {availability_threshold_:P2}.",
                   KSP.UI.Screens.MessageSystemButton.MessageButtonColor.GREEN,
                   KSP.UI.Screens.MessageSystemButton.ButtonIcons.COMPLETE));
         }
       } else {
-        if (!alerted_) {
+        if (!alerted_ && (telecom.last_universal_time > last_alert_time_ + telecom.max_alert_rate_in_days_ * 86400)) {
           alerted_ = true;
-          TimeWarp.fetch.CancelAutoWarp();
-          TimeWarp.SetRate(
-              TimeWarp.fetch.warpRates.IndexOf(1),
-              instant: true,
-              postScreenMessage: false);
+          last_alert_time_ = telecom.last_universal_time;
+          if (telecom.stop_warp_in_sim_ || !RP0.SpaceCenterManagement.Instance.IsSimulatedFlight) {
+            TimeWarp.fetch.CancelAutoWarp();
+            TimeWarp.SetRate(
+                TimeWarp.fetch.warpRates.IndexOf(1),
+                instant: true,
+                postScreenMessage: false);
+          }
           ScreenMessages.PostScreenMessage(
-              $@"WARNING: {service_name_}: availability is below {
-              availability_threshold_:P2}.",
-              30, ScreenMessageStyle.UPPER_CENTER, XKCDColors.Orange);
+                $@"WARNING: {service_name_}: availability is below {availability_threshold_:P2}.",
+                30, ScreenMessageStyle.UPPER_CENTER, XKCDColors.Orange);
           KSP.UI.Screens.MessageSystem.Instance.AddMessage(
-              new KSP.UI.Screens.MessageSystem.Message(
-                  messageTitle: $"Out of SLA on {service_name_}",
-                  message: $@"The availability is {metric_.description
-              }, below the target of {availability_threshold_:P2}.",
-                  KSP.UI.Screens.MessageSystemButton.MessageButtonColor.ORANGE,
-                  KSP.UI.Screens.MessageSystemButton.ButtonIcons.ALERT));
+                new KSP.UI.Screens.MessageSystem.Message(
+                    messageTitle: $"Out of SLA on {service_name_}",
+                    message: $@"The availability is {metric_.description}, below the target of {availability_threshold_:P2}.",
+                    KSP.UI.Screens.MessageSystemButton.MessageButtonColor.ORANGE,
+                    KSP.UI.Screens.MessageSystemButton.ButtonIcons.ALERT));
         }
       }
     }
@@ -52,5 +54,7 @@
     private AvailabilityMetric metric_;
     private double availability_threshold_;
     private bool alerted_ = false;
+    private double last_alert_time_ = 0;
+    private double last_restore_time_ = 0;
   }
 }

--- a/Telecom/network.cs
+++ b/Telecom/network.cs
@@ -44,7 +44,6 @@ namespace σκοπός {
       foreach (ConfigNode node in connection_nodes) {
         connections_[node.GetValue("name")].Load(node);
       }
-      Telecom.Instance.ReloadContractConnections(null);
       (CommNet.CommNetScenario.Instance as RACommNetScenario).Network.InvalidateCache();    // Inform RA of changes to the node list.
     }
 

--- a/Telecom/network.cs
+++ b/Telecom/network.cs
@@ -44,7 +44,7 @@ namespace σκοπός {
       foreach (ConfigNode node in connection_nodes) {
         connections_[node.GetValue("name")].Load(node);
       }
-      ReloadContractConnections();
+      Telecom.Instance.ReloadContractConnections(null);
       (CommNet.CommNetScenario.Instance as RACommNetScenario).Network.InvalidateCache();    // Inform RA of changes to the node list.
     }
 
@@ -92,13 +92,14 @@ namespace σκοπός {
       station_node.AddValue("isKSC", false);
       station_node.AddValue("isHome", false);
       station_node.AddValue("icon", "RealAntennas/radio-antenna");
+      Telecom.Log($"Ground TL is {RACommNetScenario.GroundStationTechLevel}");
       foreach (var antenna in node.GetNodes("Antenna")) {
         Telecom.Log($"antenna for {name}: {antenna}");
-        Telecom.Log($"Ground TL is {RACommNetScenario.GroundStationTechLevel}");
         station_node.AddNode(antenna);
       }
       station.Configure(station_node, body);
       if (RACommNetScenario.GroundStations.TryGetValue(station.nodeName, out RACommNetHome oldStation)) { 
+        Telecom.Log($"Ground station {station.nodeName} was already registered in RA, deleting the old instance");
         RACommNetScenario.GroundStations.Remove(station.nodeName);
         UnityEngine.Object.Destroy(oldStation);
       }

--- a/Telecom/telecom.cs
+++ b/Telecom/telecom.cs
@@ -204,6 +204,10 @@ namespace σκοπός {
     public double last_universal_time => ut_;
     [KSPField(isPersistant = true)]
     private double ut_;
+    [KSPField(isPersistant = true)]
+    internal double max_alert_rate_in_days_ = 0;
+    [KSPField(isPersistant = true)]
+    public bool stop_warp_in_sim_ = true;
     private KSP.UI.Screens.ApplicationLauncherButton toolbar_button_;
   }
 }

--- a/Telecom/telecom.cs
+++ b/Telecom/telecom.cs
@@ -73,6 +73,7 @@ namespace σκοπός {
       }
       Log("Creating Network");
       network = new Network(serialized_network_);
+      ReloadContractConnections(null);
       enabled = true;
       GameEvents.Contract.onAccepted.Add(ReloadContractConnections);
       GameEvents.Contract.onFinished.Add(ReloadContractConnections);
@@ -93,7 +94,7 @@ namespace σκοπός {
     private IEnumerator DelayedContractReload(Contracts.Contract data) {
       on_contracts_changed_cr_running = true;
       yield return new UnityEngine.WaitForFixedUpdate();
-      while (!Contracts.ContractSystem.loaded) {
+      while (!Contracts.ContractSystem.loaded && network != null) {
         yield return new UnityEngine.WaitForEndOfFrame();
       }
       network.ReloadContractConnections();


### PR DESCRIPTION
Fix Contracted Connection Monitoring and Add User-Configurable Alerting

A roll-up PR of a big bugfix, user alerting QoL enhancements, and a few minor fixes.  Each commit is mostly self-contained.

Removing the contract scanning from FixedUpdate created a race condition with the contract system.  When loading the network, KSP's Contract system is not yet alive, so scanning its contracts for connections to monitor produces an empty list.  This bug was introduced in the previous PR that fixed the interaction with RA and its node caches on scene switches.  This is a more properly polled solution to checking the Contract system.

Add user configurability to the alert rate.
Add user configurability to warp-stopping behavior [only during RP-1 simulations].