### PR TITLE
Change contract text color for disconnected contracts and connections

### DIFF
--- a/Telecom/main_window.cs
+++ b/Telecom/main_window.cs
@@ -66,8 +66,7 @@ internal class MainWindow : principia.ksp_plugin_adapter.SupervisedWindowRendere
         }
       }
       var ok_style = UnityEngine.GUI.skin.label;
-      var disconnected_style = principia.ksp_plugin_adapter.Style.Warning(
-        UnityEngine.GUI.skin.label);
+      var disconnected_style = principia.ksp_plugin_adapter.Style.Warning(ok_style);
 
       foreach (var contract_connections in telecom_.network.connections_by_contract) {
         var contract = contract_connections.Key;
@@ -117,7 +116,6 @@ internal class MainWindow : principia.ksp_plugin_adapter.SupervisedWindowRendere
               for (int i = 0; i < point_to_multipoint.rx_names.Length; ++i) {
                 var services = point_to_multipoint.channel_services[i];
                 bool available = services.basic.available;
-                var style = available ? ok_style : disconnected_style;
                 string status = available ? "OK" : "Disconnected";
                 var style = available ? ok_style : disconnected_style;
                 var rx = telecom_.network.GetStation(point_to_multipoint.rx_names[i]);


### PR DESCRIPTION
If any connection in a contract is disconnected, changes the text colour for that contract to orange. Likewise, for connections in a contract, when expanded the text colour of disconnected connections will be orange (similar to #33, though this changes the entire line rather than just the status).

This allows checking the status of all contracts at a glance in the Skopos window, to ensure that taking a new contract didn't break maintenance for a different contract without having to open and check all connections over all contracts.

Does not attempt to resolve #6. Also, the current implementation can result in rapidly flashing text if the availability for a connection changes rapidly (e.g. during timewarp). Performance impact appears to be minimal, as far as I can tell. 

I am not particularly attached to the colour, I just want disconnected contracts to be visually distinguishable at a glance.

Example image:
<img width="500" height="1024" alt="image" src="https://github.com/user-attachments/assets/a91720bf-7e92-4b44-a004-ed74c9fbe6e3" />