### PR TITLE
Fix Skopos ground stations not being rendered

### DIFF
--- a/Telecom/network.cs
+++ b/Telecom/network.cs
@@ -67,8 +67,7 @@ namespace σκοπός {
           continue;
         }
         Telecom.Log($"Adding station {name}");
-        RACommNetHome new_station = MakeStation(name);
-        stations_.Add(name, new_station);
+        stations_.Add(name, MakeStation(name));
       }
     }
 
@@ -250,6 +249,5 @@ namespace σκοπός {
     public Dictionary<Contracts.Contract, List<Connection>> connections_by_contract  { get; } =
         new Dictionary<Contracts.Contract, List<Connection>>();
     public HashSet<Connection> contracted_connections { get; } = new HashSet<Connection>();
-    public HashSet<RACommNetHome> needs_site_node { get;} = new HashSet<RACommNetHome>();
   }
 }

--- a/Telecom/telecom.cs
+++ b/Telecom/telecom.cs
@@ -86,13 +86,11 @@ namespace σκοπός {
     }
 
     internal IEnumerator UpdateGroundStationNode(RACommNetHome station) {
-      Log($"SiteNode {station.name} creation stalling for station CommNetHomes to create...");
-      while (network is null || network.AllGround().Any(node => node.Comm == null) || !(RACommNetUI.Instance is RACommNetUI))  {
+      Log($"Creating GroundStationSiteNode for {station.name}...");
+      while (network is null || station.Comm is null || !(RACommNetUI.Instance is RACommNetUI))  {
         yield return new UnityEngine.WaitForEndOfFrame();
       } // Stall for RACommNetHomes.
       (RACommNetUI.Instance as RACommNetUI).ConstructSiteNode(station); 
-      // This can no-op if RACommNetUI.Instance is null. This is okay, since it prevents a hanging coroutine from sticking around forever.
-      // And if there's no CommNetUI, then there's nothing to display anyway, so it should be okay if the SiteNodes aren't created yet?
     }
 
     private bool on_contracts_changed_cr_running = false;


### PR DESCRIPTION
As of v1.1.0.0, all Skopos telecom stations are not rendered in the map view, even if Show Network is checked.

As far as I can tell, this is because all Skopos stations are loaded when the `Network` object is constructed, which happens in a coroutine fired during the `Start` timing. However, [the code responsible for generating `SiteNode`s (MapUI/RACommNetUI.cs in RealAntennas)](https://github.com/KSP-RO/RealAntennas/blob/master/src/RealAntennasProject/MapUI/RACommNetUI.cs#L40)  for ground stations *also* runs during the `Start` timing. To be frank, I'm not sure exactly how these timings interact, but testing with debug prints on the loop in the linked code showed that no `SiteNode`s were being created for Skopos stations.

Previous versions of Skopos created the `Network` object during OnLoad, which I *think* happens when the save is loaded? I don't know when this is in relation to `Start`. That being said, moving the construction of `network` into OnLoad made the ground stations show up again. After that, moving the cache invalidation for the RA Network out of the Network constructor and back into `CreateNetwork` made it so that Skopos doesn't hang waiting for RA.

This is kind of a quick and dirty fix. Testing on my save seems to indicate it works (and also makes the short disconnect burst while Skopos initialises shorter). That being said, moving Network construction might have additional consequences I am unaware of.

<img width="644" height="555" alt="image" src="https://github.com/user-attachments/assets/de1b06c3-fe4b-469d-b43a-3955c57b4c33" />

(image to show it actually works, with the colour changes from the latest build)