### PR TITLE
Duplex routing unnecessarily clones RoutingNetworkUsage

### DIFF
--- a/Telecom/routing.cs
+++ b/Telecom/routing.cs
@@ -51,19 +51,29 @@ namespace σκοπός {
         public double power ;
       }
 
-      public double power { get; private set; } = 0;
+      private double power_ = 0;
+      private double fake_power_ = 0;
+      public double power => power_ + fake_power_;
 
-      public void AddUsages(SingleUsage[] broadcast, double multiplier = 1, bool fake = false) {
-        power += (from usage in broadcast select usage.power).Max() * multiplier;
+      public void AddUsages(SingleUsage[] broadcast, bool fake = false) {
+        var delta = (from usage in broadcast select usage.power).Max();
         if (!fake) {
+          power_ += delta;
           usages_.Add(broadcast);
+        } else {
+          fake_power_ += delta;
         }
+      }
+
+      public void ResetFakeChanges() {
+        fake_power_ = 0;
       }
 
       public PowerBreakdown Clone() {
         return new PowerBreakdown{
           usages_ = usages.Select(usages => usages.ToArray()).ToList(),
-          power = power,
+          power_ = power_,
+          fake_power_ = fake_power_
         };
       }
 
@@ -80,20 +90,29 @@ namespace σκοπός {
         public double spectrum ;
       }
 
-      public double spectrum { get; private set; } = 0;
+      private double spectrum_ = 0;
+      private double fake_spectrum_ = 0;
+      public double spectrum => spectrum_ + fake_spectrum_;
 
 
-      public void AddUsages(SingleUsage[] usage, double multiplier = 1, bool fake = false) {
-        spectrum += usage[0].spectrum * multiplier;
+      public void AddUsages(SingleUsage[] usage, bool fake = false) {
         if (!fake) {
+          spectrum_ += usage[0].spectrum;
           usages_.Add(usage);
+        } else {
+          fake_spectrum_ += usage[0].spectrum;
         }
+      }
+
+      public void ResetFakeChanges() {
+        fake_spectrum_ = 0;
       }
 
       public SpectrumBreakdown Clone() {
         return new SpectrumBreakdown{
           usages_ = usages.Select(usages => usages.ToArray()).ToList(),
-          spectrum = spectrum
+          spectrum_ = spectrum_,
+          fake_spectrum_ = fake_spectrum_
         };
       }
 
@@ -246,7 +265,7 @@ namespace σκοπός {
     }
     RoutingNetworkUsage current_usage = (usage != NetworkUsage.None) ? (RoutingNetworkUsage) usage : new RoutingNetworkUsage(this, usage);
     foreach (var link in forward[0].links) {
-      current_usage.UseLinkNoBroadcast(link.Unsourced(), one_way_data_rate, multiplier: 1, fake: true);
+      current_usage.UseLinkNoBroadcast(link.Unsourced(), one_way_data_rate, fake: true);
     }
     if (FindChannels(destination,
                      new[]{source},
@@ -255,12 +274,12 @@ namespace σκοπός {
                      current_usage,
                      out Channel[] backward) == Unavailable) {
       foreach (var link in forward[0].links) {
-        current_usage.UseLinkNoBroadcast(link.Unsourced(), one_way_data_rate, multiplier: -1, fake: true);
+        current_usage.RemoveFakeLink(link.Unsourced());
       }
       return null;
     }
     foreach (var link in forward[0].links) {
-      current_usage.UseLinkNoBroadcast(link.Unsourced(), one_way_data_rate, multiplier: -1, fake: true);
+        current_usage.RemoveFakeLink(link.Unsourced());
     }
     return new Circuit(forward[0], backward[0]);
   }
@@ -366,7 +385,7 @@ namespace σκοπός {
             entry => entry.Key,
             entry => entry.Value.Clone());
       }
-    } // Weakly clone (without usage details)
+    }
 
     public void Clear() {
       tx_power_usage_.Clear();
@@ -415,16 +434,14 @@ namespace σκοπός {
     // Therefore multiplier modifies the power/spectrum usage, and the fake flag indicates to not save the new usages
     public void UseLinks(IList<SourcedLink> links,
                          double data_rate,
-                         double multiplier = 1,
                          bool fake = false) {
       EnsureSameTxAntennaAndTL(from sourced in links select sourced.link);
-      UseTxPower(links, data_rate, multiplier, fake);
-      UseSpectrum(links, data_rate, multiplier, fake);
+      UseTxPower(links, data_rate, fake);
+      UseSpectrum(links, data_rate, fake);
     }
 
     private void UseTxPower(IList<SourcedLink> links,
                             double data_rate,
-                            double multiplier = 1,
                             bool fake = false) {
       if (routing_.multiple_tracking_.Contains(links[0].link.tx)) {
         return;
@@ -438,12 +455,11 @@ namespace σκοπός {
                         link = sourced,
                         power = sourced.link.TxPowerUsageFromDataRate(data_rate),
                     }).ToArray();
-      tx_power_usage_[tx_antenna].AddUsages(usages, multiplier, fake);
+      tx_power_usage_[tx_antenna].AddUsages(usages, fake);
     }
 
     private void UseSpectrum(IList<SourcedLink> links, 
                             double data_rate,
-                            double multiplier = 1,
                             bool fake = false) {
       double usage = links[0].link.SpectrumUsageFromDataRate(data_rate);
       
@@ -462,7 +478,7 @@ namespace σκοπός {
         if (!spectrum_usage_.ContainsKey(rx_antenna)) {
           spectrum_usage_.Add(rx_antenna, new SpectrumBreakdown());
         }
-        spectrum_usage_[rx_antenna].AddUsages(usages, multiplier, fake);
+        spectrum_usage_[rx_antenna].AddUsages(usages, fake);
       }
       RealAntennaDigital tx_antenna = links[0].link.tx_antenna;
       if (routing_.multiple_tracking_.Contains(links[0].link.tx)) {
@@ -477,11 +493,11 @@ namespace σκοπός {
                 link = link,
                 kind = SpectrumBreakdown.SingleUsage.Kind.Transmit,
                 spectrum = usage,
-          }).ToArray(), multiplier, fake);
+          }).ToArray(), fake);
     }
 
     // Faster version of UseLinks optimized for single links.
-    public void UseLinkNoBroadcast(SourcedLink link, double data_rate, double multiplier = 1, bool fake = false) {
+    public void UseLinkNoBroadcast(SourcedLink link, double data_rate, bool fake = false) {
       if (routing_.multiple_tracking_.Contains(link.link.tx)) {
         return;
       }
@@ -494,7 +510,7 @@ namespace σκοπός {
         new PowerBreakdown.SingleUsage{
                 link = link,
                 power = link.link.TxPowerUsageFromDataRate(data_rate),
-      } }, multiplier, fake);
+      } }, fake);
 
       double spectrum_usage = link.link.SpectrumUsageFromDataRate(data_rate);
       
@@ -509,7 +525,7 @@ namespace σκοπός {
                   link = link,
                   kind = SpectrumBreakdown.SingleUsage.Kind.Receive,
                   spectrum = spectrum_usage
-        } }, multiplier, fake);
+        } }, fake);
       }
 
       if (!routing_.multiple_tracking_.Contains(link.link.tx)) {
@@ -521,7 +537,21 @@ namespace σκοπός {
                   link = link,
                   kind = SpectrumBreakdown.SingleUsage.Kind.Transmit,
                   spectrum = spectrum_usage
-        } }, multiplier, fake);
+        } }, fake);
+      }
+    }
+
+    public void RemoveFakeLink(SourcedLink link) {
+      RealAntennaDigital rx_antenna = link.link.rx_antenna;
+      if (spectrum_usage_.ContainsKey(rx_antenna)) {
+        spectrum_usage_[rx_antenna].ResetFakeChanges();
+      }
+      RealAntennaDigital tx_antenna = link.link.tx_antenna;
+      if (spectrum_usage_.ContainsKey(tx_antenna)) {
+        spectrum_usage_[tx_antenna].ResetFakeChanges();
+      }
+      if (tx_power_usage_.ContainsKey(tx_antenna)) {
+        tx_power_usage_[tx_antenna].ResetFakeChanges();
       }
     }
 

--- a/Telecom/routing.cs
+++ b/Telecom/routing.cs
@@ -53,23 +53,16 @@ namespace σκοπός {
 
       public double power { get; private set; } = 0;
 
-      public void AddUsages(SingleUsage[] broadcast) {
-        power += (from usage in broadcast select usage.power).Max();
-        if (!(usages_ is null)) { // If this fails, we are a weak clone and should not bother tracking usage arrays.
+      public void AddUsages(SingleUsage[] broadcast, double multiplier = 1, bool fake = false) {
+        power += (from usage in broadcast select usage.power).Max() * multiplier;
+        if (!fake) {
           usages_.Add(broadcast);
-        } 
+        }
       }
 
       public PowerBreakdown Clone() {
         return new PowerBreakdown{
           usages_ = usages.Select(usages => usages.ToArray()).ToList(),
-          power = power,
-        };
-      }
-
-      public PowerBreakdown WeakClone() {
-        return new PowerBreakdown{
-          usages_ = null,
           power = power,
         };
       }
@@ -89,9 +82,10 @@ namespace σκοπός {
 
       public double spectrum { get; private set; } = 0;
 
-      public void AddUsages(SingleUsage[] usage) {
-        spectrum += usage[0].spectrum;
-        if (!(usages_ is null)) { // If this fails, we are a weak clone and should not bother tracking usage arrays.
+
+      public void AddUsages(SingleUsage[] usage, double multiplier = 1, bool fake = false) {
+        spectrum += usage[0].spectrum * multiplier;
+        if (!fake) {
           usages_.Add(usage);
         }
       }
@@ -99,13 +93,6 @@ namespace σκοπός {
       public SpectrumBreakdown Clone() {
         return new SpectrumBreakdown{
           usages_ = usages.Select(usages => usages.ToArray()).ToList(),
-          spectrum = spectrum
-        };
-      }
-
-      public SpectrumBreakdown WeakClone() {
-        return new SpectrumBreakdown{
-          usages_ = null,
           spectrum = spectrum
         };
       }
@@ -191,14 +178,14 @@ namespace σκοπός {
         current_network_usage_);
     if (circuit != null) {
       foreach (OrientedLink link in circuit.forward.links) {
-        current_network_usage_.UseLinks(
-            new[] {new SourcedLink(connection, circuit.forward, link)},
+        current_network_usage_.UseLinkNoBroadcast(
+            new SourcedLink(connection, circuit.forward, link),
             one_way_data_rate);
       }
       foreach (OrientedLink link in circuit.backward.links) {
-        current_network_usage_.UseLinks(
-            new[] {new SourcedLink(connection, circuit.backward, link)},
-            one_way_data_rate);
+        current_network_usage_.UseLinkNoBroadcast(
+          new SourcedLink(connection, circuit.backward, link),
+          one_way_data_rate);
       }
     }
     return circuit;
@@ -238,7 +225,7 @@ namespace σκοπός {
           from link in channel.links
           group new SourcedLink(connection, channel, link) by link.tx_antenna;
       foreach (var links in links_by_tx_antenna) {
-        current_network_usage_.UseLinks(links, data_rate);
+        current_network_usage_.UseLinks(links.ToList(), data_rate);
       }
     }
     return availability;
@@ -257,18 +244,23 @@ namespace σκοπός {
                      out Channel[] forward) == Unavailable) {
       return null;
     }
-    var usage_with_forward_channel = new RoutingNetworkUsage(this, usage);
+    RoutingNetworkUsage current_usage = (usage != NetworkUsage.None) ? (RoutingNetworkUsage) usage : new RoutingNetworkUsage(this, usage);
     foreach (var link in forward[0].links) {
-      usage_with_forward_channel.UseLinks(new[]{link.Unsourced()},
-                                          one_way_data_rate);
+      current_usage.UseLinkNoBroadcast(link.Unsourced(), one_way_data_rate, multiplier: 1, fake: true);
     }
     if (FindChannels(destination,
                      new[]{source},
                      round_trip_latency_limit - forward[0].latency,
                      one_way_data_rate,
-                     usage_with_forward_channel,
+                     current_usage,
                      out Channel[] backward) == Unavailable) {
+      foreach (var link in forward[0].links) {
+        current_usage.UseLinkNoBroadcast(link.Unsourced(), one_way_data_rate, multiplier: -1, fake: true);
+      }
       return null;
+    }
+    foreach (var link in forward[0].links) {
+      current_usage.UseLinkNoBroadcast(link.Unsourced(), one_way_data_rate, multiplier: -1, fake: true);
     }
     return new Circuit(forward[0], backward[0]);
   }
@@ -369,10 +361,10 @@ namespace σκοπός {
       if (other is RoutingNetworkUsage nontrival) {
         tx_power_usage_ = nontrival.tx_power_usage_.ToDictionary(
             entry => entry.Key,
-            entry => entry.Value.WeakClone());
+            entry => entry.Value.Clone());
         spectrum_usage_ = nontrival.spectrum_usage_.ToDictionary(
             entry => entry.Key,
-            entry => entry.Value.WeakClone());
+            entry => entry.Value.Clone());
       }
     } // Weakly clone (without usage details)
 
@@ -416,19 +408,28 @@ namespace σκοπός {
     // Uses tx power corresponding to broadcast at the given data rate along
     // all of these links (thus at the power needed for the weakest link).
     // Also uses the necessary spectrum on all antennas involved.
-    public void UseLinks(IEnumerable<SourcedLink> links,
-                         double data_rate) {
+    
+    // The multiplier and fake attributes exist for simulation purposes
+    // FindCircuit needs to act as if the forward links are already being used
+    // while routing the backward links.
+    // Therefore multiplier modifies the power/spectrum usage, and the fake flag indicates to not save the new usages
+    public void UseLinks(IList<SourcedLink> links,
+                         double data_rate,
+                         double multiplier = 1,
+                         bool fake = false) {
       EnsureSameTxAntennaAndTL(from sourced in links select sourced.link);
-      UseTxPower(links, data_rate);
-      UseSpectrum(links, data_rate);
+      UseTxPower(links, data_rate, multiplier, fake);
+      UseSpectrum(links, data_rate, multiplier, fake);
     }
 
-    private void UseTxPower(IEnumerable<SourcedLink> links,
-                            double data_rate) {
-      if (routing_.multiple_tracking_.Contains(links.First().link.tx)) {
+    private void UseTxPower(IList<SourcedLink> links,
+                            double data_rate,
+                            double multiplier = 1,
+                            bool fake = false) {
+      if (routing_.multiple_tracking_.Contains(links[0].link.tx)) {
         return;
       }
-      RealAntennaDigital tx_antenna = links.First().link.tx_antenna;
+      RealAntennaDigital tx_antenna = links[0].link.tx_antenna;
       if (!tx_power_usage_.ContainsKey(tx_antenna)) {
         tx_power_usage_.Add(tx_antenna, new PowerBreakdown());
       }
@@ -437,30 +438,34 @@ namespace σκοπός {
                         link = sourced,
                         power = sourced.link.TxPowerUsageFromDataRate(data_rate),
                     }).ToArray();
-      tx_power_usage_[tx_antenna].AddUsages(usages);
+      tx_power_usage_[tx_antenna].AddUsages(usages, multiplier, fake);
     }
 
-    private void UseSpectrum(IEnumerable<SourcedLink> links, double data_rate) {
-      double usage = links.First().link.SpectrumUsageFromDataRate(data_rate);
-      foreach (var sourced in links.GroupBy(l => l.link.rx_antenna)) {
-        RACommNode rx = sourced.First().link.rx;
-        RealAntennaDigital rx_antenna = sourced.First().link.rx_antenna;
-        if (routing_.multiple_tracking_.Contains(rx)) {
-          continue;
-        }
-        if (!spectrum_usage_.ContainsKey(rx_antenna)) {
-          spectrum_usage_.Add(rx_antenna, new SpectrumBreakdown());
-        }
-        spectrum_usage_[rx_antenna].AddUsages(
-            (from link in sourced select
+    private void UseSpectrum(IList<SourcedLink> links, 
+                            double data_rate,
+                            double multiplier = 1,
+                            bool fake = false) {
+      double usage = links[0].link.SpectrumUsageFromDataRate(data_rate);
+      
+      foreach (var sourced in links.GroupBy(l => l.link.rx_antenna)) { 
+        var usages = (from link in sourced select
                 new SpectrumBreakdown.SingleUsage{
                     link = link,
                     kind = SpectrumBreakdown.SingleUsage.Kind.Receive,
-                    spectrum = usage,
-            }).ToArray());
+                    spectrum = link.link.SpectrumUsageFromDataRate(data_rate),
+            }).ToArray();
+        RACommNode rx = usages[0].link.link.rx;
+        if (routing_.multiple_tracking_.Contains(rx)) {
+          continue;
+        }
+        RealAntennaDigital rx_antenna = usages[0].link.link.rx_antenna;
+        if (!spectrum_usage_.ContainsKey(rx_antenna)) {
+          spectrum_usage_.Add(rx_antenna, new SpectrumBreakdown());
+        }
+        spectrum_usage_[rx_antenna].AddUsages(usages, multiplier, fake);
       }
-      RealAntennaDigital tx_antenna = links.First().link.tx_antenna;
-      if (routing_.multiple_tracking_.Contains(links.First().link.tx)) {
+      RealAntennaDigital tx_antenna = links[0].link.tx_antenna;
+      if (routing_.multiple_tracking_.Contains(links[0].link.tx)) {
         return;
       }
       if (!spectrum_usage_.ContainsKey(tx_antenna)) {
@@ -472,7 +477,52 @@ namespace σκοπός {
                 link = link,
                 kind = SpectrumBreakdown.SingleUsage.Kind.Transmit,
                 spectrum = usage,
-          }).ToArray());
+          }).ToArray(), multiplier, fake);
+    }
+
+    // Faster version of UseLinks optimized for single links.
+    public void UseLinkNoBroadcast(SourcedLink link, double data_rate, double multiplier = 1, bool fake = false) {
+      if (routing_.multiple_tracking_.Contains(link.link.tx)) {
+        return;
+      }
+      // Tx power
+      RealAntennaDigital tx_antenna = link.link.tx_antenna;
+      if (!tx_power_usage_.ContainsKey(tx_antenna)) {
+        tx_power_usage_.Add(tx_antenna, new PowerBreakdown());
+      }
+      tx_power_usage_[tx_antenna].AddUsages(new [] {
+        new PowerBreakdown.SingleUsage{
+                link = link,
+                power = link.link.TxPowerUsageFromDataRate(data_rate),
+      } }, multiplier, fake);
+
+      double spectrum_usage = link.link.SpectrumUsageFromDataRate(data_rate);
+      
+      // Rx spectrum
+      if (!routing_.multiple_tracking_.Contains(link.link.rx)) {
+        RealAntennaDigital rx_antenna = link.link.rx_antenna;
+        if (!spectrum_usage_.ContainsKey(rx_antenna)) {
+          spectrum_usage_.Add(rx_antenna, new SpectrumBreakdown());
+        }
+        spectrum_usage_[rx_antenna].AddUsages(new[] {
+          new SpectrumBreakdown.SingleUsage{
+                  link = link,
+                  kind = SpectrumBreakdown.SingleUsage.Kind.Receive,
+                  spectrum = spectrum_usage
+        } }, multiplier, fake);
+      }
+
+      if (!routing_.multiple_tracking_.Contains(link.link.tx)) {
+        if (!spectrum_usage_.ContainsKey(link.link.tx_antenna)) {
+          spectrum_usage_.Add(tx_antenna, new SpectrumBreakdown());
+        }
+        spectrum_usage_[tx_antenna].AddUsages(new[] {
+          new SpectrumBreakdown.SingleUsage{
+                  link = link,
+                  kind = SpectrumBreakdown.SingleUsage.Kind.Transmit,
+                  spectrum = spectrum_usage
+        } }, multiplier, fake);
+      }
     }
 
     private void EnsureSameTxAntennaAndTL(IEnumerable<OrientedLink> links) {

--- a/Telecom/routing.cs
+++ b/Telecom/routing.cs
@@ -55,12 +55,21 @@ namespace σκοπός {
 
       public void AddUsages(SingleUsage[] broadcast) {
         power += (from usage in broadcast select usage.power).Max();
-        usages_.Add(broadcast);
+        if (!(usages_ is null)) { // If this fails, we are a weak clone and should not bother tracking usage arrays.
+          usages_.Add(broadcast);
+        } 
       }
 
       public PowerBreakdown Clone() {
         return new PowerBreakdown{
           usages_ = usages.Select(usages => usages.ToArray()).ToList(),
+          power = power,
+        };
+      }
+
+      public PowerBreakdown WeakClone() {
+        return new PowerBreakdown{
+          usages_ = null,
           power = power,
         };
       }
@@ -82,12 +91,21 @@ namespace σκοπός {
 
       public void AddUsages(SingleUsage[] usage) {
         spectrum += usage[0].spectrum;
-        usages_.Add(usage);
+        if (!(usages_ is null)) { // If this fails, we are a weak clone and should not bother tracking usage arrays.
+          usages_.Add(usage);
+        }
       }
 
       public SpectrumBreakdown Clone() {
         return new SpectrumBreakdown{
           usages_ = usages.Select(usages => usages.ToArray()).ToList(),
+          spectrum = spectrum
+        };
+      }
+
+      public SpectrumBreakdown WeakClone() {
+        return new SpectrumBreakdown{
+          usages_ = null,
           spectrum = spectrum
         };
       }
@@ -351,12 +369,12 @@ namespace σκοπός {
       if (other is RoutingNetworkUsage nontrival) {
         tx_power_usage_ = nontrival.tx_power_usage_.ToDictionary(
             entry => entry.Key,
-            entry => entry.Value.Clone());
+            entry => entry.Value.WeakClone());
         spectrum_usage_ = nontrival.spectrum_usage_.ToDictionary(
             entry => entry.Key,
-            entry => entry.Value.Clone());
+            entry => entry.Value.WeakClone());
       }
-    }
+    } // Weakly clone (without usage details)
 
     public void Clear() {
       tx_power_usage_.Clear();

--- a/Telecom/routing.cs
+++ b/Telecom/routing.cs
@@ -203,8 +203,8 @@ namespace σκοπός {
       }
       foreach (OrientedLink link in circuit.backward.links) {
         current_network_usage_.UseLinkNoBroadcast(
-          new SourcedLink(connection, circuit.backward, link),
-          one_way_data_rate);
+            new SourcedLink(connection, circuit.backward, link),
+            one_way_data_rate);
       }
     }
     return circuit;
@@ -267,19 +267,17 @@ namespace σκοπός {
     foreach (var link in forward[0].links) {
       current_usage.UseLinkNoBroadcast(link.Unsourced(), one_way_data_rate, fake: true);
     }
-    if (FindChannels(destination,
-                     new[]{source},
-                     round_trip_latency_limit - forward[0].latency,
-                     one_way_data_rate,
-                     current_usage,
-                     out Channel[] backward) == Unavailable) {
-      foreach (var link in forward[0].links) {
-        current_usage.RemoveFakeLink(link.Unsourced());
-      }
-      return null;
-    }
+    PointToMultipointAvailability backward_result = FindChannels(destination,
+                                                                 new[]{source},
+                                                                 round_trip_latency_limit - forward[0].latency,
+                                                                 one_way_data_rate,
+                                                                 current_usage,
+                                                                 out Channel[] backward);
     foreach (var link in forward[0].links) {
-        current_usage.RemoveFakeLink(link.Unsourced());
+      current_usage.RemoveFakeLink(link.Unsourced());
+    }
+    if (backward_result == Unavailable) {
+      return null;
     }
     return new Circuit(forward[0], backward[0]);
   }
@@ -432,7 +430,7 @@ namespace σκοπός {
     // FindCircuit needs to act as if the forward links are already being used
     // while routing the backward links.
     // Therefore multiplier modifies the power/spectrum usage, and the fake flag indicates to not save the new usages
-    public void UseLinks(IList<SourcedLink> links,
+    public void UseLinks(IEnumerable<SourcedLink> links,
                          double data_rate,
                          bool fake = false) {
       EnsureSameTxAntennaAndTL(from sourced in links select sourced.link);
@@ -440,13 +438,13 @@ namespace σκοπός {
       UseSpectrum(links, data_rate, fake);
     }
 
-    private void UseTxPower(IList<SourcedLink> links,
+    private void UseTxPower(IEnumerable<SourcedLink> links,
                             double data_rate,
                             bool fake = false) {
-      if (routing_.multiple_tracking_.Contains(links[0].link.tx)) {
+      if (routing_.multiple_tracking_.Contains(links.First().link.tx)) {
         return;
       }
-      RealAntennaDigital tx_antenna = links[0].link.tx_antenna;
+      RealAntennaDigital tx_antenna = links.First().link.tx_antenna;
       if (!tx_power_usage_.ContainsKey(tx_antenna)) {
         tx_power_usage_.Add(tx_antenna, new PowerBreakdown());
       }
@@ -458,30 +456,27 @@ namespace σκοπός {
       tx_power_usage_[tx_antenna].AddUsages(usages, fake);
     }
 
-    private void UseSpectrum(IList<SourcedLink> links, 
-                            double data_rate,
-                            bool fake = false) {
-      double usage = links[0].link.SpectrumUsageFromDataRate(data_rate);
-      
-      foreach (var sourced in links.GroupBy(l => l.link.rx_antenna)) { 
-        var usages = (from link in sourced select
-                new SpectrumBreakdown.SingleUsage{
-                    link = link,
-                    kind = SpectrumBreakdown.SingleUsage.Kind.Receive,
-                    spectrum = link.link.SpectrumUsageFromDataRate(data_rate),
-            }).ToArray();
-        RACommNode rx = usages[0].link.link.rx;
+    private void UseSpectrum(IEnumerable<SourcedLink> links, double data_rate, bool fake = false) {
+      double usage = links.First().link.SpectrumUsageFromDataRate(data_rate);
+      foreach (var sourced in links.GroupBy(l => l.link.rx_antenna)) {
+        RACommNode rx = sourced.First().link.rx;
+        RealAntennaDigital rx_antenna = sourced.First().link.rx_antenna;
         if (routing_.multiple_tracking_.Contains(rx)) {
           continue;
         }
-        RealAntennaDigital rx_antenna = usages[0].link.link.rx_antenna;
         if (!spectrum_usage_.ContainsKey(rx_antenna)) {
           spectrum_usage_.Add(rx_antenna, new SpectrumBreakdown());
         }
-        spectrum_usage_[rx_antenna].AddUsages(usages, fake);
+        spectrum_usage_[rx_antenna].AddUsages(
+            (from link in sourced select
+                new SpectrumBreakdown.SingleUsage{
+                    link = link,
+                    kind = SpectrumBreakdown.SingleUsage.Kind.Receive,
+                    spectrum = usage,
+            }).ToArray(), fake);
       }
-      RealAntennaDigital tx_antenna = links[0].link.tx_antenna;
-      if (routing_.multiple_tracking_.Contains(links[0].link.tx)) {
+      RealAntennaDigital tx_antenna = links.First().link.tx_antenna;
+      if (routing_.multiple_tracking_.Contains(links.First().link.tx)) {
         return;
       }
       if (!spectrum_usage_.ContainsKey(tx_antenna)) {
@@ -496,22 +491,8 @@ namespace σκοπός {
           }).ToArray(), fake);
     }
 
-    // Faster version of UseLinks optimized for single links.
+    // LINQ-free version of UseLinks optimized for single links.
     public void UseLinkNoBroadcast(SourcedLink link, double data_rate, bool fake = false) {
-      if (routing_.multiple_tracking_.Contains(link.link.tx)) {
-        return;
-      }
-      // Tx power
-      RealAntennaDigital tx_antenna = link.link.tx_antenna;
-      if (!tx_power_usage_.ContainsKey(tx_antenna)) {
-        tx_power_usage_.Add(tx_antenna, new PowerBreakdown());
-      }
-      tx_power_usage_[tx_antenna].AddUsages(new [] {
-        new PowerBreakdown.SingleUsage{
-                link = link,
-                power = link.link.TxPowerUsageFromDataRate(data_rate),
-      } }, fake);
-
       double spectrum_usage = link.link.SpectrumUsageFromDataRate(data_rate);
       
       // Rx spectrum
@@ -528,7 +509,16 @@ namespace σκοπός {
         } }, fake);
       }
 
-      if (!routing_.multiple_tracking_.Contains(link.link.tx)) {
+      if (!routing_.multiple_tracking_.Contains(link.link.tx)) {// Tx power
+        RealAntennaDigital tx_antenna = link.link.tx_antenna;
+        if (!tx_power_usage_.ContainsKey(tx_antenna)) {
+          tx_power_usage_.Add(tx_antenna, new PowerBreakdown());
+        }
+        tx_power_usage_[tx_antenna].AddUsages(new [] {
+          new PowerBreakdown.SingleUsage{
+                  link = link,
+                  power = link.link.TxPowerUsageFromDataRate(data_rate),
+        } }, fake);
         if (!spectrum_usage_.ContainsKey(link.link.tx_antenna)) {
           spectrum_usage_.Add(tx_antenna, new SpectrumBreakdown());
         }

--- a/Telecom/routing.cs
+++ b/Telecom/routing.cs
@@ -426,10 +426,9 @@ namespace σκοπός {
     // all of these links (thus at the power needed for the weakest link).
     // Also uses the necessary spectrum on all antennas involved.
     
-    // The multiplier and fake attributes exist for simulation purposes
-    // FindCircuit needs to act as if the forward links are already being used
-    // while routing the backward links.
-    // Therefore multiplier modifies the power/spectrum usage, and the fake flag indicates to not save the new usages
+    // The fake attribute causes the links to 1) not actually save the SingleUsage array
+    // and 2) stores the power/spectrum usage in a separate variable (fake_power/fake_spectrum)
+    // that is added to power/spectrum for routing purposes, and can be removed using RemoveFakeLink.
     public void UseLinks(IEnumerable<SourcedLink> links,
                          double data_rate,
                          bool fake = false) {

--- a/Telecom/routing.cs
+++ b/Telecom/routing.cs
@@ -244,7 +244,7 @@ namespace σκοπός {
           from link in channel.links
           group new SourcedLink(connection, channel, link) by link.tx_antenna;
       foreach (var links in links_by_tx_antenna) {
-        current_network_usage_.UseLinks(links.ToList(), data_rate);
+        current_network_usage_.UseLinks(links, data_rate);
       }
     }
     return availability;


### PR DESCRIPTION
The core issue is in this line in FindCircuit: https://github.com/mockingbirdnest/Skopos/blob/fbfbc7ee2a13030c7c1dfabda6566840e6062f0e/Telecom/routing.cs#L242

This clones the entire NetworkUsage object passed to it. We use this to temporarily add the links from the forward route to the usage, which lets us route the backwards route. However, the cost of doing this increases the larger `current_network_usage_` becomes, and is essentially quadratic in the number of connections (since we are allocating an entire new Dictionary with all of the contents of the old one every duplex connection we route!).

Therefore, I opt to add "fake" usages onto the network, which exploits the fact that we cache the total power/spectrum usage of each antenna separately from the actual `SourcedLink[]` usages. To that end, `UseLinks` and its dependencies now support two additional optional arguments, `multiplier` and `fake`. `multiplier` multiplies the power/spectrum added to the total, which we can invert for undoing a "fake" link. `fake` will cause the `SourcedLink[] usages` array to not be added, which prevents having to clean it up later when we restore the original state.

FindCircuit now operates on the passed NetworkUsage directly. It adds "fake" usages corresponding to the forward links (which increase the reported power/spectrum use properly without adding the links), before routing the backward Channel. It receives its answer, then cleans up after itself by adding "fake" usages with multiplier -1 corresponding to the forward links, which undoes their effects.

However, we must take care to support `FindCircuitInIsolation` as well. If it is passed `NetworkUsage.None`, then `FindCircuit` will default to cloning the network usage as normal, so that the forward links can be checked against the backwards links properly. 

Also, there is hypothetically a floating-point precision error possible here, since we are not generally guaranteed that `x + y - y == x` for any given `double x, y`. Addressing this could be done by adding an additional field to PowerBreakdown and SpectrumBreakdown that tracks the "fake" power/spectrum added directly.

Finally, since we add quite a lot of single links with no opportunity for broadcast, I spun off a Linq-free version of `UseLinks` that optimises for adding a single link to the NetworkUsage. This makes it so we can skip the awkward iteration and group-by checks when there is only one link to add. This version is in `UseLinkNoBroadcast`.