### PR TITLE
Vessel Overview window

### DIFF
--- a/Telecom/Telecom.csproj
+++ b/Telecom/Telecom.csproj
@@ -117,6 +117,7 @@
     <Compile Include="time.cs" />
     <Compile Include="telecom.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="vessel_overview.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Telecom/main_window.cs
+++ b/Telecom/main_window.cs
@@ -8,6 +8,7 @@ namespace σκοπός {
 internal class MainWindow : principia.ksp_plugin_adapter.SupervisedWindowRenderer {
   public MainWindow(Telecom telecom) : base(telecom) {
     telecom_ = telecom;
+    vessel_overview_ = new VesselOverview(telecom);
   }
 
   public bool show_network { get; private set; } = false;
@@ -33,6 +34,10 @@ internal class MainWindow : principia.ksp_plugin_adapter.SupervisedWindowRendere
         alert_rate_limit_text = UnityEngine.GUILayout.TextField(alert_rate_limit_text);
         double.TryParse(alert_rate_limit_text, out telecom_.max_alert_rate_in_days_);
         UnityEngine.GUILayout.Label($"days ({telecom_.max_alert_rate_in_days_})");
+      }
+
+      using (new UnityEngine.GUILayout.HorizontalScope()) {
+        vessel_overview_.RenderButton();
       }
 
       using (new UnityEngine.GUILayout.HorizontalScope()) {
@@ -150,6 +155,7 @@ internal class MainWindow : principia.ksp_plugin_adapter.SupervisedWindowRendere
     antenna_inspectors_;
 
   private Telecom telecom_;
+  private VesselOverview vessel_overview_;
   private string alert_rate_limit_text;
   private readonly Dictionary<Contracts.Contract, bool> open_contracts_ =
       new Dictionary<Contracts.Contract, bool>();

--- a/Telecom/main_window.cs
+++ b/Telecom/main_window.cs
@@ -28,16 +28,13 @@ internal class MainWindow : principia.ksp_plugin_adapter.SupervisedWindowRendere
       using (new UnityEngine.GUILayout.HorizontalScope()) {
         show_network = UnityEngine.GUILayout.Toggle(show_network, "Show network");
         telecom_.stop_warp_in_sim_ = UnityEngine.GUILayout.Toggle(telecom_.stop_warp_in_sim_, "Alerts stop warp in RP-1 sim");
+        vessel_overview_.RenderButton();
       }
       using (new UnityEngine.GUILayout.HorizontalScope()) {
         UnityEngine.GUILayout.Label("Suppress duplicate SLA alerts within");
         alert_rate_limit_text = UnityEngine.GUILayout.TextField(alert_rate_limit_text);
         double.TryParse(alert_rate_limit_text, out telecom_.max_alert_rate_in_days_);
         UnityEngine.GUILayout.Label($"days ({telecom_.max_alert_rate_in_days_})");
-      }
-
-      using (new UnityEngine.GUILayout.HorizontalScope()) {
-        vessel_overview_.RenderButton();
       }
 
       using (new UnityEngine.GUILayout.HorizontalScope()) {
@@ -156,6 +153,7 @@ internal class MainWindow : principia.ksp_plugin_adapter.SupervisedWindowRendere
 
   private Telecom telecom_;
   private VesselOverview vessel_overview_;
+  internal RACommNode focused_vessel;
   private string alert_rate_limit_text;
   private readonly Dictionary<Contracts.Contract, bool> open_contracts_ =
       new Dictionary<Contracts.Contract, bool>();

--- a/Telecom/main_window.cs
+++ b/Telecom/main_window.cs
@@ -153,7 +153,7 @@ internal class MainWindow : principia.ksp_plugin_adapter.SupervisedWindowRendere
 
   private Telecom telecom_;
   private VesselOverview vessel_overview_;
-  internal RACommNode focused_vessel;
+  internal readonly HashSet<RACommNode> focused_vessel = new HashSet<RACommNode>();
   private string alert_rate_limit_text;
   private readonly Dictionary<Contracts.Contract, bool> open_contracts_ =
       new Dictionary<Contracts.Contract, bool>();

--- a/Telecom/telecom.cs
+++ b/Telecom/telecom.cs
@@ -1,11 +1,11 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using RealAntennas;
 using RealAntennas.MapUI;
-using System.IO;
-using System.Runtime.CompilerServices;
-using System.Collections;
 using RealAntennas.Network;
 
 namespace σκοπός {
@@ -200,7 +200,8 @@ namespace σκοπός {
         ui.OverrideShownCones.Add(station);
       }
       foreach (Vessel vessel in FlightGlobals.Vessels) {
-        if (vessel?.connection?.Comm is RACommNode node) {
+        if (vessel?.connection?.Comm is RACommNode node &&
+            (main_window_.focused_vessel is null || node == main_window_.focused_vessel)) {
           ui.OverrideShownCones.Add(node);
         }
       }
@@ -208,7 +209,8 @@ namespace σκοπός {
         if (link.a is RACommNode node_a &&
             (node_a.ParentVessel != null || stations.Contains(node_a)) &&
             link.b is RACommNode node_b &&
-            (node_b.ParentVessel != null || stations.Contains(node_b))) {
+            (node_b.ParentVessel != null || stations.Contains(node_b)) &&
+            (main_window_.focused_vessel is null || node_a == main_window_.focused_vessel || node_b == main_window_.focused_vessel)) {
           ui.OverrideShownLinks.Add(link);
         }
       }

--- a/Telecom/telecom.cs
+++ b/Telecom/telecom.cs
@@ -200,7 +200,7 @@ namespace σκοπός {
         ui.OverrideShownCones.Add(station);
       }
       foreach (Vessel vessel in FlightGlobals.Vessels) {
-        if (vessel?.connection?.Comm is RACommNode node && main_window_.focused_vessel.Contains(node)) {
+        if (vessel?.connection?.Comm is RACommNode node && ShowNode(node)) {
           ui.OverrideShownCones.Add(node);
         }
       }
@@ -209,10 +209,14 @@ namespace σκοπός {
             (node_a.ParentVessel != null || stations.Contains(node_a)) &&
             link.b is RACommNode node_b &&
             (node_b.ParentVessel != null || stations.Contains(node_b)) &&
-            (main_window_.focused_vessel.Contains(node_a) || main_window_.focused_vessel.Contains(node_b))) {
+            (ShowNode(node_a) || ShowNode(node_b))) {
           ui.OverrideShownLinks.Add(link);
         }
       }
+    }
+
+    private bool ShowNode(RACommNode node) {
+        return main_window_.focused_vessel.Count == 0 || main_window_.focused_vessel.Contains(node);
     }
 
 

--- a/Telecom/telecom.cs
+++ b/Telecom/telecom.cs
@@ -200,8 +200,7 @@ namespace σκοπός {
         ui.OverrideShownCones.Add(station);
       }
       foreach (Vessel vessel in FlightGlobals.Vessels) {
-        if (vessel?.connection?.Comm is RACommNode node &&
-            (main_window_.focused_vessel is null || node == main_window_.focused_vessel)) {
+        if (vessel?.connection?.Comm is RACommNode node && main_window_.focused_vessel.Contains(node)) {
           ui.OverrideShownCones.Add(node);
         }
       }
@@ -210,7 +209,7 @@ namespace σκοπός {
             (node_a.ParentVessel != null || stations.Contains(node_a)) &&
             link.b is RACommNode node_b &&
             (node_b.ParentVessel != null || stations.Contains(node_b)) &&
-            (main_window_.focused_vessel is null || node_a == main_window_.focused_vessel || node_b == main_window_.focused_vessel)) {
+            (main_window_.focused_vessel.Contains(node_a) || main_window_.focused_vessel.Contains(node_b))) {
           ui.OverrideShownLinks.Add(link);
         }
       }

--- a/Telecom/vessel_overview.cs
+++ b/Telecom/vessel_overview.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using CommNet;
 using CommNet.Network;
 using RealAntennas;
-using Smooth.Slinq.Collections;
 
 namespace σκοπός {
   internal class VesselOverview : principia.ksp_plugin_adapter.SupervisedWindowRenderer {
@@ -46,6 +45,9 @@ namespace σκοπός {
       using (new UnityEngine.GUILayout.HorizontalScope()) {
         UnityEngine.GUILayout.Label($"Total antenna spectrum usage: {RATools.PrettyPrint(total_spectrum_usage)}Hz");
         UnityEngine.GUILayout.Label($"Total (normalized) power usage: {total_normalised_power_usage:P2}");
+        if (UnityEngine.GUILayout.Button(new UnityEngine.GUIContent("Reset Link Display", "Show all Skopos links, clearing any filter applied by the Show Links buttons."))) {
+          telecom_.main_window_.focused_vessel = null;
+        }
       }
       
       using (new UnityEngine.GUILayout.HorizontalScope()) { // Yet another budget table. Yippee.
@@ -59,7 +61,11 @@ namespace σκοπός {
                   ScheduleShrink();
                   return;
                 }
-                UnityEngine.GUILayout.Label($"{node.displayName}");
+                string name = node.displayName;
+                if (row == telecom_.main_window_.focused_vessel) {
+                  name = $">> {node.displayName} <<";
+                }
+                UnityEngine.GUILayout.Label($"{name}");
               } else if (row is RealAntennaDigital antenna) {
                 UnityEngine.GUILayout.Label($"{antenna.Name} -> {antenna.Target}");
               }
@@ -118,7 +124,9 @@ namespace σκοπός {
           foreach (var row in rows) {
             using (new UnityEngine.GUILayout.HorizontalScope()) {
               if (row is RACommNode node) {
-                UnityEngine.GUILayout.Label($" "); // Padding space.
+                if (UnityEngine.GUILayout.Button(new UnityEngine.GUIContent("Show Links", "Shows only links with one end at this vessel. No effect unless Show network is ticked."))) {
+                  telecom_.main_window_.focused_vessel = node;
+                }
               } else if (row is RealAntennaDigital antenna) {
                 if (!telecom_.main_window_.antenna_inspectors.TryGetValue(
                       antenna, out var inspector)) {

--- a/Telecom/vessel_overview.cs
+++ b/Telecom/vessel_overview.cs
@@ -1,0 +1,147 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CommNet;
+using CommNet.Network;
+using RealAntennas;
+using Smooth.Slinq.Collections;
+
+namespace σκοπός {
+  internal class VesselOverview : principia.ksp_plugin_adapter.SupervisedWindowRenderer {
+    public VesselOverview(Telecom telecom) 
+      : base(telecom) {
+      telecom_ = telecom;
+    }
+    protected override string Title => "Σκοπός Telecom vessel overview";
+
+    protected override void RenderWindowContents(int window_id) {
+      var node_grouped_antennas = telecom_.network.routing_.usage.Users()
+        .GroupBy(antenna => antenna.ParentNode)
+        .Where(grouping => !(((RACommNode) grouping.Key).ParentVessel is null))
+        .OrderBy(grouping => ((RACommNode) grouping.Key).ParentVessel.GetDisplayName());
+
+      List<object> rows = new List<object>();
+
+      double total_spectrum_usage = 0;
+      double total_normalised_power_usage = 0;
+       
+      foreach (var antenna_group in node_grouped_antennas) {
+        RACommNode node = (RACommNode) antenna_group.Key;
+        rows.Add(node);
+        bool res = false;
+        if (!open_vessels_.TryGetValue(node, out res)) {
+          open_vessels_[node] = false;
+        }
+        total_spectrum_usage += antenna_group.Select(antenna => telecom_.network.routing_.usage.SpectrumUsage(antenna)).Sum();
+        total_normalised_power_usage += antenna_group.Select(antenna => telecom_.network.routing_.usage.TxPowerUsage(antenna)).Sum();
+        if (res) {
+          foreach (RealAntennaDigital antenna in antenna_group.OrderBy(antenna => $"{antenna.Name} -> {antenna.Target}")) {
+            rows.Add(antenna);
+          }
+        }
+      }
+
+      using (new UnityEngine.GUILayout.HorizontalScope()) {
+        UnityEngine.GUILayout.Label($"Total antenna spectrum usage: {RATools.PrettyPrint(total_spectrum_usage)}Hz");
+        UnityEngine.GUILayout.Label($"Total (normalized) power usage: {total_normalised_power_usage:P2}");
+      }
+      
+      using (new UnityEngine.GUILayout.HorizontalScope()) { // Yet another budget table. Yippee.
+        using (new UnityEngine.GUILayout.VerticalScope()) { // name
+          foreach (var row in rows) {
+            using (new UnityEngine.GUILayout.HorizontalScope()) {
+              if (row is RACommNode node) {
+                if (UnityEngine.GUILayout.Button(
+                    open_vessels_[node] ? "−" : "+", GUILayoutWidth(1))) {
+                  open_vessels_[node] = !open_vessels_[node];
+                  ScheduleShrink();
+                  return;
+                }
+                UnityEngine.GUILayout.Label($"{node.displayName}");
+              } else if (row is RealAntennaDigital antenna) {
+                UnityEngine.GUILayout.Label($"{antenna.Name} -> {antenna.Target}");
+              }
+            }
+          }
+        }
+        using (new UnityEngine.GUILayout.VerticalScope()) { // used spectrum
+          foreach (var row in rows) {
+            using (new UnityEngine.GUILayout.HorizontalScope()) {
+              if (row is RACommNode node) {
+                UnityEngine.GUILayout.Label($" "); // Padding space.
+              } else if (row is RealAntennaDigital antenna) {
+                UnityEngine.GUILayout.FlexibleSpace();
+                UnityEngine.GUILayout.Label($"{RATools.PrettyPrint(telecom_.network.routing_.usage.SpectrumUsage(antenna))}Hz /");
+              }
+            }
+          }
+        }
+        using (new UnityEngine.GUILayout.VerticalScope()) { // total spectrum
+          foreach (var row in rows) {
+            using (new UnityEngine.GUILayout.HorizontalScope()) {
+              if (row is RACommNode node) {
+                UnityEngine.GUILayout.Label($" "); // Padding space.
+              } else if (row is RealAntennaDigital antenna) {
+                UnityEngine.GUILayout.FlexibleSpace();
+                UnityEngine.GUILayout.Label($"{RATools.PrettyPrint(antenna.RFBand.ChannelWidth)}Hz");
+              }
+            }
+          }
+        }
+        using (new UnityEngine.GUILayout.VerticalScope()) { // used power
+          foreach (var row in rows) {
+            using (new UnityEngine.GUILayout.HorizontalScope()) {
+              if (row is RACommNode node) {
+                UnityEngine.GUILayout.Label($" "); // Padding space.
+              } else if (row is RealAntennaDigital antenna) {
+                UnityEngine.GUILayout.FlexibleSpace();
+                UnityEngine.GUILayout.Label($"{RATools.PrettyPrint(antenna.PowerDrawLinear * 1e-3 * telecom_.network.routing_.usage.TxPowerUsage(antenna))}W /");
+              }
+            }
+          }
+        }
+        using (new UnityEngine.GUILayout.VerticalScope()) { // total power
+          foreach (var row in rows) {
+            using (new UnityEngine.GUILayout.HorizontalScope()) {
+              if (row is RACommNode node) {
+                UnityEngine.GUILayout.Label($" "); // Padding space.
+              } else if (row is RealAntennaDigital antenna) {
+                UnityEngine.GUILayout.FlexibleSpace();
+                UnityEngine.GUILayout.Label($"{RATools.PrettyPrint(antenna.PowerDrawLinear * 1e-3)}W");
+              }
+            }
+          }
+        }
+        using (new UnityEngine.GUILayout.VerticalScope()) { // button for antennas
+          foreach (var row in rows) {
+            using (new UnityEngine.GUILayout.HorizontalScope()) {
+              if (row is RACommNode node) {
+                UnityEngine.GUILayout.Label($" "); // Padding space.
+              } else if (row is RealAntennaDigital antenna) {
+                if (!telecom_.main_window_.antenna_inspectors.TryGetValue(
+                      antenna, out var inspector)) {
+                  inspector = new AntennaInspector(telecom_, antenna);
+                  telecom_.main_window_.antenna_inspectors[antenna] = inspector;
+                }
+                inspector.RenderButton();
+              }
+            }
+          }
+        }
+      }
+      
+      UnityEngine.GUI.DragWindow();
+    }
+
+    public void RenderButton() {
+      if (UnityEngine.GUILayout.Button("Vessel Overview")) {
+        Toggle();
+      }
+    }
+
+    private Telecom telecom_;
+    private readonly Dictionary<RACommNode, bool> open_vessels_ = new Dictionary<RACommNode, bool>();
+  }
+}

--- a/Telecom/vessel_overview.cs
+++ b/Telecom/vessel_overview.cs
@@ -46,7 +46,7 @@ namespace σκοπός {
         UnityEngine.GUILayout.Label($"Total antenna spectrum usage: {RATools.PrettyPrint(total_spectrum_usage)}Hz");
         UnityEngine.GUILayout.Label($"Total (normalized) power usage: {total_normalised_power_usage:P2}");
         if (UnityEngine.GUILayout.Button(new UnityEngine.GUIContent("Reset Link Display", "Show all Skopos links, clearing any filter applied by the Show Links buttons."))) {
-          telecom_.main_window_.focused_vessel = null;
+          telecom_.main_window_.focused_vessel.Clear();
         }
       }
       
@@ -124,8 +124,13 @@ namespace σκοπός {
           foreach (var row in rows) {
             using (new UnityEngine.GUILayout.HorizontalScope()) {
               if (row is RACommNode node) {
-                if (UnityEngine.GUILayout.Button(new UnityEngine.GUIContent("Show Links", "Shows only links with one end at this vessel. No effect unless Show network is ticked."))) {
-                  telecom_.main_window_.focused_vessel = node;
+                string label = telecom_.main_window_.focused_vessel.Contains(node) ? "Hide Links" : "Show Links";
+                if (UnityEngine.GUILayout.Button(new UnityEngine.GUIContent(label, "Shows/hides links with one end at this vessel. No effect unless Show network is ticked."))) {
+                  if (telecom_.main_window_.focused_vessel.Contains(node)) {
+                    telecom_.main_window_.focused_vessel.Remove(node);
+                  } else {
+                    telecom_.main_window_.focused_vessel.Add(node);
+                  }
                 }
               } else if (row is RealAntennaDigital antenna) {
                 if (!telecom_.main_window_.antenna_inspectors.TryGetValue(


### PR DESCRIPTION
Resolves #41 by adding a new window that displays vessel information and lets the user filter down Skopos-specific connections to just links that include a particular vessel. The window also contains some routing statistics. These aren't particularly useful on their own but they are nice to have when comparing different routing algorithms. Each vessel row can also expand to summarize the antenna utilisation on that vessel.
<img width="1274" height="969" alt="image" src="https://github.com/user-attachments/assets/a2e8e4e4-2771-46b9-9a93-3cc7a741797b" />

I am not certain that the current UX behaviour is the best, so I would appreciate suggestions on improving the UX of the current design.