### PR TITLE
Only run the routing algorithm when RA updates

### DIFF
--- a/Telecom/RuntimeMetrics.cs
+++ b/Telecom/RuntimeMetrics.cs
@@ -1,9 +1,9 @@
 ﻿namespace σκοπός {
     internal class RuntimeMetrics {
         public RuntimeMetrics() { }
-        public int num_fixed_update_iterations_ = 0;
-        public double fixed_update_runtime_ = 0;
+        public int num_iterations_ = 0;
+        public double total_runtime_ = 0;
 
-        public double AverageFixedUpdateRuntime => fixed_update_runtime_ / num_fixed_update_iterations_;
+        public double AverageRefreshRuntime => total_runtime_ / num_iterations_;
     }
 }

--- a/Telecom/main_window.cs
+++ b/Telecom/main_window.cs
@@ -37,8 +37,8 @@ internal class MainWindow : principia.ksp_plugin_adapter.SupervisedWindowRendere
 
       using (new UnityEngine.GUILayout.HorizontalScope()) {
         UnityEngine.GUILayout.Label($"Contracted connections: {telecom_.network.contracted_connections.Count}");
-        UnityEngine.GUILayout.Label($"Fixed Updates: {telecom_.runtimeMetrics_.num_fixed_update_iterations_}");
-        UnityEngine.GUILayout.Label($"Average Runtime: {telecom_.runtimeMetrics_.AverageFixedUpdateRuntime:F2} ms");
+        UnityEngine.GUILayout.Label($"Total Runs: {telecom_.runtimeMetrics_.num_iterations_}");
+        UnityEngine.GUILayout.Label($"Average Total Runtime: {telecom_.runtimeMetrics_.AverageRefreshRuntime:F2} ms");
       }
 
       var inspected_connections = connection_inspectors_.Keys.ToArray();

--- a/Telecom/network.cs
+++ b/Telecom/network.cs
@@ -176,8 +176,8 @@ namespace σκοπός {
         }
       }
       refresh_watch_.Stop();
-      metrics.num_fixed_update_iterations_++;
-      metrics.fixed_update_runtime_ = refresh_watch_.Elapsed.TotalMilliseconds;
+      metrics.num_iterations_++;
+      metrics.total_runtime_ = refresh_watch_.Elapsed.TotalMilliseconds;
       UnityEngine.Profiling.Profiler.EndSample();
     }
 

--- a/Telecom/network.cs
+++ b/Telecom/network.cs
@@ -176,7 +176,7 @@ namespace σκοπός {
         }
       }
       refresh_watch_.Stop();
-      metrics.num_iterations_++;
+      ++metrics.num_iterations_;
       metrics.total_runtime_ = refresh_watch_.Elapsed.TotalMilliseconds;
       UnityEngine.Profiling.Profiler.EndSample();
     }

--- a/Telecom/network.cs
+++ b/Telecom/network.cs
@@ -165,16 +165,6 @@ namespace σκοπός {
       var metrics = Telecom.Instance.runtimeMetrics_;
       refresh_watch_.Start();
       UpdateConnections();
-      foreach (RealAntennaDigital antenna in routing_.usage.Transmitters()) {
-        if ((antenna?.ParentNode as RACommNode).ParentVessel is Vessel vessel) {
-          Kerbalism.ConsumeResource(
-              vessel,
-              "ElectricCharge",
-              // PowerDrawLinear is in mW, ElectricCharge is in kJ.
-              routing_.usage.TxPowerUsage(antenna) * antenna.PowerDrawLinear * 1e-6 * TimeWarp.fixedDeltaTime,
-              "Σκοπός telecom");
-        }
-      }
       refresh_watch_.Stop();
       ++metrics.num_iterations_;
       metrics.total_runtime_ = refresh_watch_.Elapsed.TotalMilliseconds;
@@ -194,6 +184,19 @@ namespace σκοπός {
       foreach (var connection in connections_.Values) {
         if (contracted_connections.Contains(connection)) {
           connection.AttemptConnection(routing_, this, Telecom.Instance.last_universal_time);
+        }
+      }
+    }
+
+    public void ConsumeElectricCharge() {
+      foreach (RealAntennaDigital antenna in routing_?.usage?.Transmitters()) {
+        if ((antenna?.ParentNode as RACommNode).ParentVessel is Vessel vessel) {
+          Kerbalism.ConsumeResource(
+              vessel,
+              "ElectricCharge",
+              // PowerDrawLinear is in mW, ElectricCharge is in kJ.
+              routing_.usage.TxPowerUsage(antenna) * antenna.PowerDrawLinear * 1e-6 * TimeWarp.fixedDeltaTime,
+              "Σκοπός telecom");
         }
       }
     }

--- a/Telecom/telecom.cs
+++ b/Telecom/telecom.cs
@@ -70,24 +70,15 @@ namespace σκοπός {
     }
 
     private void AddPostUpdateHandler() {
-      if (RACommNetNetwork.Instance?.CommNet?.OnNetworkPostUpdate is Action) {
-        previous_on_network_post_update = RACommNetNetwork.Instance?.CommNet?.OnNetworkPostUpdate;
+      ((RACommNetwork) RACommNetNetwork.Instance.CommNet).NetworkUpdateComplete.Add(PostUpdateHandler);
       }
-      if (!(RACommNetNetwork.Instance?.CommNet is null)) {
-        RACommNetNetwork.Instance.CommNet.OnNetworkPostUpdate = PostUpdateHandler;
-      }
-    }
 
     private void PostUpdateHandler() {
-      //const double MIN_UPDATE_INTERVAL = 0.1;
-      if (previous_on_network_post_update is Action) previous_on_network_post_update();
-      else {
-        double now = Planetarium.GetUniversalTime();
-        if (last_refresh_ut <= now) {
+      if ( ((RACommNetwork) RACommNetNetwork.Instance.CommNet).LastUpdateUT > last_update_ut) {
           do_refresh = true;
+        last_update_ut = ((RACommNetwork) RACommNetNetwork.Instance.CommNet).LastUpdateUT;
         }
       }
-    }
 
     private IEnumerator CreateNetwork() {
       while (RACommNetScenario.RACN == null || !CommNet.CommNetNetwork.Initialized) {
@@ -203,9 +194,8 @@ namespace σκοπός {
       }
       
       if (do_refresh) {
+        do_refresh = false; // Unset now so that it can reset if RA updates while we're working.
         network?.Refresh();
-        last_refresh_ut = ut_;
-        do_refresh = false;
       }
     }
 
@@ -258,7 +248,6 @@ namespace σκοπός {
 
     internal RuntimeMetrics runtimeMetrics_ = new RuntimeMetrics();
     internal bool do_refresh = false;
-    private double last_refresh_ut = 0;
-    private Action previous_on_network_post_update = null;
+    private double last_update_ut;
   }
 }

--- a/Telecom/telecom.cs
+++ b/Telecom/telecom.cs
@@ -71,7 +71,7 @@ namespace σκοπός {
 
     private void AddPostUpdateHandler() {
       ((RACommNetwork) RACommNetNetwork.Instance.CommNet).NetworkUpdateComplete.Add(PostUpdateHandler);
-      }
+    }
 
     private void PostUpdateHandler() {
       if ( ((RACommNetwork) RACommNetNetwork.Instance.CommNet).LastUpdateUT > last_update_ut) {

--- a/Telecom/telecom.cs
+++ b/Telecom/telecom.cs
@@ -75,10 +75,10 @@ namespace σκοπός {
 
     private void PostUpdateHandler() {
       if ( ((RACommNetwork) RACommNetNetwork.Instance.CommNet).LastUpdateUT > last_update_ut) {
-          do_refresh = true;
+        do_refresh = true;
         last_update_ut = ((RACommNetwork) RACommNetNetwork.Instance.CommNet).LastUpdateUT;
-        }
       }
+    }
 
     private IEnumerator CreateNetwork() {
       while (RACommNetScenario.RACN == null || !CommNet.CommNetNetwork.Initialized) {

--- a/Telecom/telecom.cs
+++ b/Telecom/telecom.cs
@@ -48,6 +48,7 @@ namespace σκοπός {
       Log("Starting");
       enabled = false;
       GameEvents.CommNet.OnNetworkInitialized.Add(NetworkInitializedNotify);
+      GameEvents.CommNet.OnNetworkInitialized.Add(AddPostUpdateHandler);
       GameEvents.Contract.onContractsLoaded.Add(NotifyContractsLoaded);
       StartCoroutine(CreateNetwork());
     }
@@ -66,6 +67,26 @@ namespace σκοπός {
 
     private void NetworkInitializedNotify() {
       Log("CommNet Network Initialization fired.");
+    }
+
+    private void AddPostUpdateHandler() {
+      if (RACommNetNetwork.Instance?.CommNet?.OnNetworkPostUpdate is Action) {
+        previous_on_network_post_update = RACommNetNetwork.Instance?.CommNet?.OnNetworkPostUpdate;
+      }
+      if (!(RACommNetNetwork.Instance?.CommNet is null)) {
+        RACommNetNetwork.Instance.CommNet.OnNetworkPostUpdate = PostUpdateHandler;
+      }
+    }
+
+    private void PostUpdateHandler() {
+      //const double MIN_UPDATE_INTERVAL = 0.1;
+      if (previous_on_network_post_update is Action) previous_on_network_post_update();
+      else {
+        double now = Planetarium.GetUniversalTime();
+        if (last_refresh_ut <= now) {
+          do_refresh = true;
+        }
+      }
     }
 
     private IEnumerator CreateNetwork() {
@@ -180,7 +201,12 @@ namespace σκοπός {
         // Time does not advance in the VAB, but after a revert, it is incorrectly stuck in the past.
         ut_ = Planetarium.GetUniversalTime();
       }
-      network?.Refresh();
+      
+      if (do_refresh) {
+        network?.Refresh();
+        last_refresh_ut = ut_;
+        do_refresh = false;
+      }
     }
 
     private void LateUpdate() {
@@ -231,5 +257,8 @@ namespace σκοπός {
     private KSP.UI.Screens.ApplicationLauncherButton toolbar_button_;
 
     internal RuntimeMetrics runtimeMetrics_ = new RuntimeMetrics();
+    internal bool do_refresh = false;
+    private double last_refresh_ut = 0;
+    private Action previous_on_network_post_update = null;
   }
 }

--- a/Telecom/telecom.cs
+++ b/Telecom/telecom.cs
@@ -74,9 +74,9 @@ namespace σκοπός {
     }
 
     private void PostUpdateHandler() {
-      if ( ((RACommNetwork) RACommNetNetwork.Instance.CommNet).LastUpdateUT > last_update_ut) {
-        do_refresh = true;
-        last_update_ut = ((RACommNetwork) RACommNetNetwork.Instance.CommNet).LastUpdateUT;
+      if ( ((RACommNetwork) RACommNetNetwork.Instance.CommNet).LastUpdateUT > last_update_ut_) {
+        do_refresh_ = true;
+        last_update_ut_ = ((RACommNetwork) RACommNetNetwork.Instance.CommNet).LastUpdateUT;
       }
     }
 
@@ -193,8 +193,8 @@ namespace σκοπός {
         ut_ = Planetarium.GetUniversalTime();
       }
       
-      if (do_refresh) {
-        do_refresh = false; // Unset now so that it can reset if RA updates while we're working.
+      if (do_refresh_) {
+        do_refresh_ = false; // Unset now so that it can reset if RA updates while we're working.
         network?.Refresh();
       }
     }
@@ -247,7 +247,7 @@ namespace σκοπός {
     private KSP.UI.Screens.ApplicationLauncherButton toolbar_button_;
 
     internal RuntimeMetrics runtimeMetrics_ = new RuntimeMetrics();
-    internal bool do_refresh = false;
-    private double last_update_ut;
+    internal bool do_refresh_ = false;
+    private double last_update_ut_;
   }
 }

--- a/Telecom/telecom.cs
+++ b/Telecom/telecom.cs
@@ -56,6 +56,7 @@ namespace σκοπός {
     public void OnDestroy() {
       Log("Destroying");
       GameEvents.CommNet.OnNetworkInitialized.Remove(NetworkInitializedNotify);
+      GameEvents.CommNet.OnNetworkInitialized.Remove(AddPostUpdateHandler);
       GameEvents.Contract.onAccepted.Remove(ReloadContractConnections);
       GameEvents.Contract.onFinished.Remove(ReloadContractConnections);    
       GameEvents.Contract.onContractsLoaded.Remove(NotifyContractsLoaded);
@@ -74,9 +75,10 @@ namespace σκοπός {
     }
 
     private void PostUpdateHandler() {
-      if ( ((RACommNetwork) RACommNetNetwork.Instance.CommNet).LastUpdateUT > last_update_ut_) {
+      double network_last_ut = ((RACommNetwork) RACommNetNetwork.Instance.CommNet).LastUpdateUT;
+      if (network_last_ut > last_update_ut_) {
         do_refresh_ = true;
-        last_update_ut_ = ((RACommNetwork) RACommNetNetwork.Instance.CommNet).LastUpdateUT;
+        last_update_ut_ = network_last_ut;
       }
     }
 

--- a/Telecom/telecom.cs
+++ b/Telecom/telecom.cs
@@ -199,6 +199,7 @@ namespace σκοπός {
         do_refresh_ = false; // Unset now so that it can reset if RA updates while we're working.
         network?.Refresh();
       }
+      network?.ConsumeElectricCharge();
     }
 
     private void LateUpdate() {


### PR DESCRIPTION
If RA has not updated since the last time we ran the routing algorithm, there is no point in re-running it - we will obtain the same result.

Currently, this makes the game run at slideshow pace on rails warp, since this effectively makes RA runs block the current FixedUpdate for 20ms or so while Skopos routes its connections. However, this makes standard gameplay much more bearable, since we only run the routing algorithm 4-5 times per second instead of every physics tick.

Once we combine this with a suitable routing algorithm optimisation, Skopos routing-related lag should essentially become unnoticeable.