### PR TITLE
Clean up .csproj files to reference KSPRoot

### DIFF
--- a/Telecom/Telecom.csproj
+++ b/Telecom/Telecom.csproj
@@ -34,21 +34,20 @@
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\KSP_win64 1.12.2\KSP_x64_Data\Managed\Assembly-CSharp.dll</HintPath>
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/Assembly-CSharp.dll">
+      <HintPath>$(ReferencePath)/Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="ContractConfigurator">
-      <HintPath>..\..\KSP_win64 1.12.3\GameData\ContractConfigurator\ContractConfigurator.dll</HintPath>
+    <Reference Include="$(KSPRoot)/GameData/ContractConfigurator/ContractConfigurator.dll">
+      <HintPath>$(ReferencePath)/ContractConfigurator.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="RealAntennas">
-      <HintPath>..\..\KSP_win64 1.12.2\GameData\RealAntennas\RealAntennas.dll</HintPath>
+    <Reference Include="$(KSPRoot)/GameData/RealAntennas/Plugins/RealAntennas.dll">
+      <HintPath>$(ReferencePath)/RealAntennas.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="RP0">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\Kerbal Space Program\KSP_win64 RO-PLC 1.12.3\GameData\RP-1\Plugins\RP0.dll</HintPath>
+    <Reference Include="$(KSPRoot)/GameData/RP-1/Plugins/RP0.dll">
+      <HintPath>$(ReferencePath)/RP0.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
@@ -59,34 +58,30 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\..\KSP_win64 1.12.2\KSP_x64_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+    <Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/UnityEngine.CoreModule.dll">
+      <HintPath>$(ReferencePath)/UnityEngine.CoreModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="UnityEngine.ImageConversionModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\KSP_win64 1.12.3\KSP_x64_Data\Managed\UnityEngine.ImageConversionModule.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine.IMGUIModule">
-      <HintPath>..\..\KSP_win64 1.12.2\KSP_x64_Data\Managed\UnityEngine.IMGUIModule.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine.InputLegacyModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\Kerbal Space Program\KSP_win64 RO-PLC 1.12.3\KSP_x64_Data\Managed\UnityEngine.InputLegacyModule.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine.TextRenderingModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\Kerbal Space Program\KSP_win64 RO-PLC 1.12.3\KSP_x64_Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\KSP_win64 1.12.2\KSP_x64_Data\Managed\UnityEngine.UI.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
+		<Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/UnityEngine.ImageConversionModule.dll">
+			<HintPath>$(ReferencePath)/UnityEngine.ImageConversionModule.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
+		<Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/UnityEngine.IMGUIModule.dll">
+			<HintPath>$(ReferencePath)/UnityEngine.IMGUIModule.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
+		<Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/UnityEngine.InputLegacyModule.dll">
+			<HintPath>$(ReferencePath)/UnityEngine.InputLegacyModule.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
+		<Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/UnityEngine.TextRenderingModule.dll">
+			<HintPath>$(ReferencePath)/UnityEngine.TextRenderingModule.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
+		<Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/UnityEngine.UI.dll">
+			<HintPath>$(ReferencePath)/UnityEngine.UI.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\Principia\ksp_plugin_adapter\config_node_extensions.cs">

--- a/TelecomTests/TelecomTests.csproj
+++ b/TelecomTests/TelecomTests.csproj
@@ -42,26 +42,30 @@
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\KSP_win64 RO 1.12.3\KSP_x64_Data\Managed\Assembly-CSharp.dll</HintPath>
-    </Reference>
+		<Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/Assembly-CSharp.dll">
+			<HintPath>$(ReferencePath)/Assembly-CSharp.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\MSTest.TestFramework.2.2.7\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\MSTest.TestFramework.2.2.7\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="RealAntennas">
-      <HintPath>..\..\..\KSP_win64 RO 1.12.3\GameData\RealAntennas\Plugins\RealAntennas.dll</HintPath>
-    </Reference>
+		<Reference Include="$(KSPRoot)/GameData/RealAntennas/Plugins/RealAntennas.dll">
+			<HintPath>$(ReferencePath)/RealAntennas.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="Unity.Mathematics">
-      <HintPath>..\..\..\KSP_win64 1.12.3\GameData\000_KSPBurst\Plugins\Unity.Mathematics.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\..\..\KSP_win64 1.12.3\KSP_x64_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
-    </Reference>
+		<Reference Include="$(KSPRoot)/GameData/000_KSPBurst/Plugins/Unity.Mathematics.dll">
+			<HintPath>$(ReferencePath)/Unity.Mathematics.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
+		<Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/UnityEngine.CoreModule.dll">
+			<HintPath>$(ReferencePath)/UnityEngine.CoreModule.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="priority_queue_test.cs" />
@@ -72,7 +76,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(SolutionDir)Telecom\Telecom.csproj">
+    <ProjectReference Include="$(SolutionDir)/Telecom/Telecom.csproj">
       <Project>{c56ae65d-f12b-46df-ad6a-36862a047db0}</Project>
       <Name>Telecom</Name>
     </ProjectReference>

--- a/Unlocker/Unlocker.csproj
+++ b/Unlocker/Unlocker.csproj
@@ -32,23 +32,22 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\KSP_win64 1.12.2\KSP_x64_Data\Managed\Assembly-CSharp.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="ContractConfigurator">
-      <HintPath>..\..\KSP_win64 1.12.3\GameData\ContractConfigurator\ContractConfigurator.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="RealAntennas">
-      <HintPath>..\..\KSP_win64 1.12.2\GameData\RealAntennas\RealAntennas.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="RP0">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\Kerbal Space Program\KSP_win64 RO-PLC 1.12.3\GameData\RP-1\Plugins\RP0.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
+		<Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/Assembly-CSharp.dll">
+			<HintPath>$(ReferencePath)/Assembly-CSharp.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
+		<Reference Include="$(KSPRoot)/GameData/ContractConfigurator/ContractConfigurator.dll">
+			<HintPath>$(ReferencePath)/ContractConfigurator.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
+		<Reference Include="$(KSPRoot)/GameData/RealAntennas/Plugins/RealAntennas.dll">
+			<HintPath>$(ReferencePath)/RealAntennas.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
+		<Reference Include="$(KSPRoot)/GameData/RP-1/Plugins/RP0.dll">
+			<HintPath>$(ReferencePath)/RP0.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -57,34 +56,30 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\..\KSP_win64 1.12.2\KSP_x64_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine.ImageConversionModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\KSP_win64 1.12.3\KSP_x64_Data\Managed\UnityEngine.ImageConversionModule.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine.IMGUIModule">
-      <HintPath>..\..\KSP_win64 1.12.2\KSP_x64_Data\Managed\UnityEngine.IMGUIModule.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine.InputLegacyModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\Kerbal Space Program\KSP_win64 RO-PLC 1.12.3\KSP_x64_Data\Managed\UnityEngine.InputLegacyModule.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine.TextRenderingModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\Kerbal Space Program\KSP_win64 RO-PLC 1.12.3\KSP_x64_Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\KSP_win64 1.12.2\KSP_x64_Data\Managed\UnityEngine.UI.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
+		<Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/UnityEngine.CoreModule.dll">
+			<HintPath>$(ReferencePath)/UnityEngine.CoreModule.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
+		<Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/UnityEngine.ImageConversionModule.dll">
+			<HintPath>$(ReferencePath)/UnityEngine.ImageConversionModule.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
+		<Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/UnityEngine.IMGUIModule.dll">
+			<HintPath>$(ReferencePath)/UnityEngine.IMGUIModule.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
+		<Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/UnityEngine.InputLegacyModule.dll">
+			<HintPath>$(ReferencePath)/UnityEngine.InputLegacyModule.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
+		<Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/UnityEngine.TextRenderingModule.dll">
+			<HintPath>$(ReferencePath)/UnityEngine.TextRenderingModule.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
+		<Reference Include="$(KSPRoot)/KSP_x64_Data/Managed/UnityEngine.UI.dll">
+			<HintPath>$(ReferencePath)/UnityEngine.UI.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Unlocker/unlocker.cs
+++ b/Unlocker/unlocker.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using KerbalConstructionTime;
+using RP0;
 
 namespace σκοπός {
   [KSPScenario(


### PR DESCRIPTION
Currently `Telecom.csproj` references a mishmash of 3 separate KSP installations. This changes the reference syntax to how [RP-1](https://github.com/KSP-RO/RP-1/blob/master/Source/RP0/RP0.csproj) handles references in its csproj, which should hopefully help enable build automation.

There are two issues:
- We still have an unstated Principia dependency for certain bits of UI code.
- TelecomTests does not run unless all references are present in the folder where it runs. By default, this manifests as a failure to load RealAntennas; however it will not properly function until all references are in the bin/Release folder.