### PR TITLE
Hold off on increasing syncom station C/N ratios

### DIFF
--- a/GameData/Skopos/telecom.cfg
+++ b/GameData/Skopos/telecom.cfg
@@ -3529,10 +3529,10 @@ skopos_telecom {
       ModulationBits = 1  //FM, FSK or PSK only?
       EncoderOverride = None - Syncom Voice
       TARGET {}
-      //If you put off this contract until 1964 tech, you can afford better than Syncom
+      //If you put off this contract until 1970 tech, you can afford better than Syncom
       UPGRADE
       {
-        TechLevel = 4
+        TechLevel = 5
         EncoderOverride = None - Early Comsat
       }
     }
@@ -3547,10 +3547,10 @@ skopos_telecom {
       ModulationBits = 1  //FM, FSK or PSK only?
       EncoderOverride = None - Syncom Voice
       TARGET {}
-      //If you put off this contract until 1964 tech, you can afford better than Syncom
+      //If you put off this contract until 1970 tech, you can afford better than Syncom
       UPGRADE
       {
-        TechLevel = 4
+        TechLevel = 5
         EncoderOverride = None - Early Comsat
       }
     }

--- a/GameData/Skopos/telecom.cfg
+++ b/GameData/Skopos/telecom.cfg
@@ -3599,10 +3599,10 @@ skopos_telecom {
       ModulationBits = 1  //FM, FSK or PSK only?
       EncoderOverride = None - Syncom Voice
       TARGET {}
-      //If you put off this contract until 1964 tech, you can afford better than Syncom
+      //If you put off this contract until 1970 tech, you can afford better than Syncom
       UPGRADE
       {
-        TechLevel = 4
+        TechLevel = 5
         EncoderOverride = None - Early Comsat
       }
     }


### PR DESCRIPTION
Wait until TL5 (70s tech) to increase the C/N ratio of syncom stations. Since the syncom contracts are only 1 year long there should be a much lower risk the player upgrades to TL5 while they are running. If the player waits until 70s tech to do the contract the connection should be trivial even with the higher C/N requirement.